### PR TITLE
fix: Request details close button overlap

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -13,10 +13,13 @@ export default function App() {
   const formData = new FormData();
   formData.append('test', 'hello');
   const makeRequest = () => {
-    fetch('https://postman-echo.com/post', {
-      method: 'POST',
-      body: JSON.stringify({ test: 'hello' }),
-    });
+    fetch(
+      'https://postman-echo.com/post?query=some really long query that goes onto multiple lines so we can test what happens',
+      {
+        method: 'POST',
+        body: JSON.stringify({ test: 'hello' }),
+      }
+    );
     fetch('https://postman-echo.com/post?formData', {
       method: 'POST',
       body: formData,

--- a/src/components/ResultItem.tsx
+++ b/src/components/ResultItem.tsx
@@ -12,6 +12,7 @@ interface Props {
 const ResultItem: React.FC<Props> = ({ style, request, onPress }) => {
   const styles = useThemedStyles(themedStyles);
   const theme = useTheme();
+  const onDetailsPage = !onPress;
   const getUrlTextColor = (status: number) => {
     if (status >= 400) {
       return {
@@ -74,7 +75,12 @@ const ResultItem: React.FC<Props> = ({ style, request, onPress }) => {
         <Text style={styles.time}>{getTime(request.startTime)}</Text>
       </View>
       <Text
-        style={[styles.text, styles.content, getUrlTextColor(request.status)]}
+        style={[
+          styles.text,
+          styles.content,
+          getUrlTextColor(request.status),
+          onDetailsPage && styles.paddedUrl,
+        ]}
       >
         {request.url}
       </Text>
@@ -128,6 +134,9 @@ const themedStyles = (theme: Theme) =>
       color: theme.colors.muted,
       marginTop: 5,
       marginHorizontal: 2,
+    },
+    paddedUrl: {
+      paddingVertical: 20,
     },
   });
 


### PR DESCRIPTION
Resolves #20 

- Add some padding to the request url when on the details page to stop long urls overlapping close button

![image](https://user-images.githubusercontent.com/5689874/93026026-cc832f80-f5fa-11ea-8e74-d2b5aa9f1db6.png)
