### PR TITLE
Grouped the Request and Response Sections

### DIFF
--- a/src/components/RequestDetails.tsx
+++ b/src/components/RequestDetails.tsx
@@ -111,9 +111,9 @@ const RequestDetails: React.FC<Props> = ({ request, onClose }) => {
       <ResultItem request={request} style={styles.info} />
       <ScrollView style={styles.scrollView} nestedScrollEnabled>
         <Headers title="Request Headers" headers={request.requestHeaders} />
-        <Headers title="Response Headers" headers={request.responseHeaders} />
         <Header shareContent={requestBody}>Request Body</Header>
         <LargeText>{requestBody}</LargeText>
+        <Headers title="Response Headers" headers={request.responseHeaders} />
         <Header shareContent={responseBody}>Response Body</Header>
         <LargeText>{responseBody}</LargeText>
         <Header>More</Header>


### PR DESCRIPTION
Hey @alexbrazier!

I love the project so far and it is a great alternative to some paid programs. I have included it into a large enterprise application that I work on, as a development tool for Developers, QA, and non technical users to be able to resolve API related defects faster.

I changed the order of the Request details screen so that the request headers and body, would be together so you can see them at the same time. Like wise with the response header and body.

Let me know what you think.

Thanks,
Spencer

ps I have a few other things I would like to PR, if you are open to it.