### PR TITLE
Changed Inflight Request Status Color to Text Color

### DIFF
--- a/src/components/ResultItem.tsx
+++ b/src/components/ResultItem.tsx
@@ -23,6 +23,9 @@ const ResultItem: React.FC<Props> = ({ style, request, onPress }) => {
     return {};
   };
   const getStatusTextColor = (status: number) => {
+    if (status < 0) {
+      return theme.colors.text;
+    }
     if (status < 400) {
       return theme.colors.statusGood;
     }


### PR DESCRIPTION
Instead of showing green for API request that have not been completed yet, I have changed it to the theme text color.

![Screenshot_1600907993](https://user-images.githubusercontent.com/25213226/94087944-a3ba2180-fdd4-11ea-8891-7937bf2cbab5.png)
