### PR TITLE
fix: Request not showing up until response received

### DIFF
--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -82,6 +82,7 @@ export default class Logger {
       startTime: Date.now(),
       dataSent: data,
     });
+    this.callback(this.requests);
   };
 
   private responseCallback = (


### PR DESCRIPTION
Fixes #32 

Fix issue that stops a pending request from being displayed while the logger is open until the request finishes.

## Demo
![delay demo](https://user-images.githubusercontent.com/5689874/94320414-c428de00-ff84-11ea-85ed-3724688a6e86.gif)
