### PR TITLE
fix: Disable the logger if used on a web project

### DIFF
--- a/src/index.web.tsx
+++ b/src/index.web.tsx
@@ -1,0 +1,16 @@
+import { StartNetworkLoggingOptions } from './types';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const startNetworkLogging = (options?: StartNetworkLoggingOptions) => {
+  console.warn('startNetworkLogging is not implemented on this platform');
+};
+
+export const getRequests = () => [];
+
+export const clearRequests = () => {};
+
+export { getBackHandler } from './backHandler';
+
+export { ThemeName } from './theme';
+
+export default () => null;


### PR DESCRIPTION
The logger relies on internal react-native dependencies that are only available for native apps. This change disables the logger on the web so it can be installed on cross platform projects.

Closes #52 (hopefully)