### PR TITLE
ThemeName is a type so export it as a type

### DIFF
--- a/src/index.web.tsx
+++ b/src/index.web.tsx
@@ -11,6 +11,6 @@ export const clearRequests = () => {};
 
 export { getBackHandler } from './backHandler';
 
-export { ThemeName } from './theme';
+export type { ThemeName } from './theme';
 
 export default () => null;


### PR DESCRIPTION
Prevents his message

../node_modules/react-native-network-logger/lib/module/index.web.js:14
Attempted import error: 'ThemeName' is not exported from './theme'.