### PR TITLE
fix: Issue with response body not loading on ios on RN 0.71.x

### DIFF
--- a/src/components/RequestDetails.tsx
+++ b/src/components/RequestDetails.tsx
@@ -59,9 +59,8 @@ const LargeText: React.FC<{ children: string }> = ({ children }) => {
         style={[styles.content, styles.largeContent]}
         multiline
         editable={false}
-      >
-        {children}
-      </TextInput>
+        value={children}
+      />
     );
   }
 


### PR DESCRIPTION
- closes #73

The original reason for using `TextInput` was from https://github.com/facebook/react-native/pull/24387 which still seems to be an issue for large blocks of text. Using `value` seems to work the same way for previous versions of React Native and `children` seems to be broken in `0.71.x`.


| Before | After |
| ------ | ------ |
<img width="340" alt="image" src="https://user-images.githubusercontent.com/5689874/225759522-9eeae67d-4fdb-4516-9e8e-c49d679c8122.png"> | <img width="332" alt="image" src="https://user-images.githubusercontent.com/5689874/225759467-0bc1908a-9af0-4d01-97c4-3d1951246670.png">
