### PR TITLE
Fixed requests not being updated when maxRequests is reached

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -49,7 +49,7 @@ export default function App() {
 
   startNetworkLogging({
     ignoredHosts: ['192.168.1.28', '127.0.0.1'],
-    maxRequests: 500,
+    maxRequests: 20,
     ignoredUrls: ['https://httpstat.us/other'],
     ignoredPatterns: [/^POST http:\/\/(192|10)/],
   });

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -207,4 +207,13 @@ export default class Logger {
     this.requests = [];
     this.callback(this.requests);
   };
+
+  // dispose in tests
+  private dispose = () => {
+    this.enabled = false;
+    nextXHRId = 0;
+    this.requests = [];
+    this.callback(this.requests);
+    this.xhrIdMap.clear();
+  };
 }

--- a/src/__tests__/Logger.spec.ts
+++ b/src/__tests__/Logger.spec.ts
@@ -241,6 +241,9 @@ describe('openCallback', () => {
     logger.openCallback('POST', url2, xhr);
     expect(logger.getRequests()[0].url).toEqual(url2);
     expect(logger.getRequests()[1].url).toEqual(url1);
+
+    // @ts-expect-error
+    logger.dispose();
   });
 
   it('should ignore requests that have ignored hosts', () => {
@@ -257,22 +260,27 @@ describe('openCallback', () => {
     logger.openCallback('POST', url2, xhr);
     expect(logger.getRequests()[0].url).toEqual(url1);
     expect(logger.getRequests()).toHaveLength(1);
+
+    // @ts-expect-error
+    logger.dispose();
   });
 
   it('should ignore requests that have ignored urls', () => {
     const logger = new Logger();
     logger.enableXHRInterception({ ignoredUrls: ['http://ignored.com/test'] });
 
-    const xhr = {};
     const url1 = 'http://ignored.com/1';
     const url2 = 'http://ignored.com/test';
 
     // @ts-expect-error
-    logger.openCallback('POST', url1, xhr);
+    logger.openCallback('POST', url1, { _index: 0 });
     // @ts-expect-error
-    logger.openCallback('POST', url2, xhr);
+    logger.openCallback('POST', url2, { _index: 1 });
     expect(logger.getRequests()[0].url).toEqual(url1);
     expect(logger.getRequests()).toHaveLength(1);
+
+    // @ts-expect-error
+    logger.dispose();
   });
 
   it('should ignore requests that match pattern', () => {
@@ -281,24 +289,26 @@ describe('openCallback', () => {
       ignoredPatterns: [/^HEAD /, /^POST http:\/\/ignored/],
     });
 
-    const xhr = {};
     const url1 = 'http://allowed.com/1';
     const url2 = 'http://ignored.com/test';
 
     // @ts-expect-error
-    logger.openCallback('POST', url1, xhr);
+    logger.openCallback('POST', url1, { _index: 0 });
     // @ts-expect-error
-    logger.openCallback('POST', url2, xhr);
+    logger.openCallback('POST', url2, { _index: 1 });
     // @ts-expect-error
-    logger.openCallback('HEAD', url2, xhr);
+    logger.openCallback('HEAD', url2, { _index: 2 });
     // @ts-expect-error
-    logger.openCallback('PUT', url2, xhr);
+    logger.openCallback('PUT', url2, { _index: 3 });
     // Requests should be in reverse order
     expect(logger.getRequests()[1].url).toEqual(url1);
     expect(logger.getRequests()[1].method).toEqual('POST');
     expect(logger.getRequests()[0].url).toEqual(url2);
     expect(logger.getRequests()[0].method).toEqual('PUT');
     expect(logger.getRequests()).toHaveLength(2);
+
+    // @ts-expect-error
+    logger.dispose();
   });
 
   it('should retrieve requests when it is restricted by maxRequests', () => {
@@ -312,19 +322,11 @@ describe('openCallback', () => {
     // @ts-expect-error
     logger.openCallback('POST', url, { _index: 0 });
     // @ts-expect-error
-    logger.sendCallback('data', { _index: 0 });
-    // @ts-expect-error
     logger.openCallback('GET', url, { _index: 1 });
-    // @ts-expect-error
-    logger.sendCallback('', { _index: 1 });
     // @ts-expect-error
     logger.openCallback('HEAD', url, { _index: 2 });
     // @ts-expect-error
-    logger.sendCallback('', { _index: 2 });
-    // @ts-expect-error
     logger.openCallback('PUT', url, { _index: 3 });
-    // @ts-expect-error
-    logger.sendCallback('data', { _index: 3 });
 
     // Requests should be in reverse order
     expect(logger.getRequests()[0].method).toEqual('PUT');
@@ -333,7 +335,11 @@ describe('openCallback', () => {
 
     // @ts-expect-error
     expect(logger.getRequest(0)?.method).toBeUndefined();
+    const first = logger.getRequests()[0];
     // @ts-expect-error
-    expect(logger.getRequest(3)?.method).toBe(logger.getRequests()[0].method);
+    expect(logger.getRequest(3)?.method).toBe(first?.method);
+
+    // @ts-expect-error
+    logger.dispose();
   });
 });

--- a/src/__tests__/Logger.spec.ts
+++ b/src/__tests__/Logger.spec.ts
@@ -25,7 +25,7 @@ beforeEach(() => {
 
 describe('enableXHRInterception', () => {
   it('should do nothing if interceptor has already been enabled', () => {
-    (warn as jest.Mock).mockImplementationOnce(() => { });
+    (warn as jest.Mock).mockImplementationOnce(() => null);
     const logger = new Logger();
 
     (XHRInterceptor.isInterceptorEnabled as jest.Mock).mockReturnValueOnce(

--- a/src/components/ResultItem.tsx
+++ b/src/components/ResultItem.tsx
@@ -47,6 +47,7 @@ const ResultItem: React.FC<Props> = ({ style, request, onPress }) => {
   const pad = (num: number) => `0${num}`.slice(-2);
 
   const getTime = (time: number) => {
+    if (time === 0) return ''; // invalid time
     const date = new Date(time);
     const hours = pad(date.getHours());
     const minutes = pad(date.getMinutes());


### PR DESCRIPTION
when the maxRequests is reached, we pop() the requests array so we always remove the last one when we reached the max, however we did not updated the xhrIdMap value when doing this. I changed this so the xhrIdMap is now getting the requestIndex directly using a function (computed get) and this constante is now a real Map().

I also added a check to make sure we don't print an invalid date like in the screenshot.

I decrased the maxRequests value in App.tsx so you we will catch it early if the issue comes back, but it affects the searchbox since only those 20 will be available, feel free to reapply 500.

![image](https://github.com/alexbrazier/react-native-network-logger/assets/23088305/bfb5c622-d52d-48ff-89e0-0d4e0d98e4d7)
