### PR TITLE
Debounce new requests changes coming from the callback

### DIFF
--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -3,6 +3,8 @@ import NetworkRequestInfo from './NetworkRequestInfo';
 import { Headers, RequestMethod, StartNetworkLoggingOptions } from './types';
 import extractHost from './utils/extractHost';
 import { warn } from './utils/logger';
+import debounce from './utils/debounce';
+import { LOGGER_REFRESH_RATE, LOGGER_MAX_REQUESTS } from './constant';
 
 let nextXHRId = 0;
 
@@ -14,19 +16,31 @@ type XHR = {
 export default class Logger {
   private requests: NetworkRequestInfo[] = [];
   private xhrIdMap: { [key: number]: number } = {};
-  private maxRequests: number = 500;
+  private maxRequests: number = LOGGER_MAX_REQUESTS;
+  private refreshRate: number = LOGGER_REFRESH_RATE;
+  private latestRequestUpdatedAt: number = 0;
   private ignoredHosts: Set<string> | undefined;
   private ignoredUrls: Set<string> | undefined;
   private ignoredPatterns: RegExp[] | undefined;
   public enabled = false;
   public paused = false;
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  callback = (requests: any[]) => {};
+  callback = (_: NetworkRequestInfo[]) => null;
 
   setCallback = (callback: any) => {
     this.callback = callback;
   };
+
+  debouncedCallback = debounce(() => {
+    if (
+      !this.latestRequestUpdatedAt ||
+      this.requests.some((r) => r.updatedAt > this.latestRequestUpdatedAt)
+    ) {
+      this.latestRequestUpdatedAt = Date.now();
+      // prevent mutation of requests for all subscribers
+      this.callback([...this.requests]);
+    }
+  }, this.refreshRate);
 
   private getRequest = (xhrIndex?: number) => {
     if (xhrIndex === undefined) return undefined;
@@ -113,7 +127,7 @@ export default class Logger {
       startTime: Date.now(),
       dataSent: data,
     });
-    this.callback(this.requests);
+    this.debouncedCallback();
   };
 
   private responseCallback = (
@@ -132,7 +146,7 @@ export default class Logger {
       responseURL,
       responseType,
     });
-    this.callback(this.requests);
+    this.debouncedCallback();
   };
 
   enableXHRInterception = (options?: StartNetworkLoggingOptions) => {
@@ -171,6 +185,16 @@ export default class Logger {
       this.ignoredHosts = new Set(options.ignoredHosts);
     }
 
+    if (options?.refreshRate) {
+      if (typeof options.refreshRate !== 'number' || options.refreshRate < 1) {
+        warn(
+          'refreshRate must be a number greater than 0. The logger has not been started.'
+        );
+        return;
+      }
+      this.refreshRate = options.refreshRate;
+    }
+
     if (options?.ignoredPatterns) {
       this.ignoredPatterns = options.ignoredPatterns;
     }
@@ -204,6 +228,7 @@ export default class Logger {
 
   clearRequests = () => {
     this.requests = [];
-    this.callback(this.requests);
+    this.latestRequestUpdatedAt = 0;
+    this.debouncedCallback();
   };
 }

--- a/src/NetworkRequestInfo.ts
+++ b/src/NetworkRequestInfo.ts
@@ -24,12 +24,14 @@ export default class NetworkRequestInfo {
   startTime: number = 0;
   endTime: number = 0;
   gqlOperation?: string;
+  updatedAt: number = 0;
 
   constructor(id: string, type: string, method: RequestMethod, url: string) {
     this.id = id;
     this.type = type;
     this.method = method;
     this.url = url;
+    this.updatedAt = Date.now();
   }
 
   get duration() {
@@ -61,6 +63,7 @@ export default class NetworkRequestInfo {
       const data = this.parseData(values.dataSent);
       this.gqlOperation = data?.operationName;
     }
+    this.updatedAt = Date.now();
   }
 
   private escapeQuotes(value: string) {

--- a/src/__tests__/Logger.spec.ts
+++ b/src/__tests__/Logger.spec.ts
@@ -1,6 +1,7 @@
 import XHRInterceptor from 'react-native/Libraries/Network/XHRInterceptor';
 import { warn } from '../utils/logger';
 import Logger from '../Logger';
+import { LOGGER_REFRESH_RATE } from '../constant';
 
 jest.mock('react-native/Libraries/Blob/FileReader', () => ({}));
 jest.mock('react-native/Libraries/Network/XHRInterceptor', () => ({
@@ -25,7 +26,7 @@ beforeEach(() => {
 
 describe('enableXHRInterception', () => {
   it('should do nothing if interceptor has already been enabled', () => {
-    (warn as jest.Mock).mockImplementationOnce(() => {});
+    (warn as jest.Mock).mockImplementationOnce(() => null);
     const logger = new Logger();
 
     (XHRInterceptor.isInterceptorEnabled as jest.Mock).mockReturnValueOnce(
@@ -168,6 +169,8 @@ describe('getRequests', () => {
 
 describe('clearRequests', () => {
   it('should clear the requests', () => {
+    jest.useFakeTimers();
+
     const logger = new Logger();
 
     logger.callback = jest.fn();
@@ -177,9 +180,13 @@ describe('clearRequests', () => {
 
     logger.clearRequests();
 
+    jest.advanceTimersByTime(LOGGER_REFRESH_RATE);
+
     expect(logger.getRequests()).toEqual([]);
     expect(logger.callback).toHaveBeenCalledTimes(1);
     expect(logger.callback).toHaveBeenCalledWith([]);
+
+    jest.useRealTimers();
   });
 });
 

--- a/src/components/NetworkLogger.tsx
+++ b/src/components/NetworkLogger.tsx
@@ -41,7 +41,7 @@ const NetworkLogger: React.FC<Props> = ({ theme = 'light', sort = 'desc' }) => {
 
   useEffect(() => {
     logger.setCallback((updatedRequests: NetworkRequestInfo[]) => {
-      setRequests(updatedRequests);
+      setRequests([...updatedRequests]);
     });
 
     logger.enableXHRInterception();

--- a/src/components/NetworkLogger.tsx
+++ b/src/components/NetworkLogger.tsx
@@ -23,9 +23,7 @@ const sortRequests = (requests: NetworkRequestInfo[], sort: 'asc' | 'desc') => {
 };
 
 const NetworkLogger: React.FC<Props> = ({ theme = 'light', sort = 'desc' }) => {
-  const [requests, setRequests] = useState(
-    sortRequests(logger.getRequests(), sort)
-  );
+  const [requests, setRequests] = useState(logger.getRequests());
   const [request, setRequest] = useState<NetworkRequestInfo>();
   const [showDetails, _setShowDetails] = useState(false);
   const [mounted, setMounted] = useState(false);
@@ -43,7 +41,7 @@ const NetworkLogger: React.FC<Props> = ({ theme = 'light', sort = 'desc' }) => {
 
   useEffect(() => {
     logger.setCallback((updatedRequests: NetworkRequestInfo[]) => {
-      setRequests(sortRequests(updatedRequests, sort));
+      setRequests(updatedRequests);
     });
 
     logger.enableXHRInterception();
@@ -104,8 +102,8 @@ const NetworkLogger: React.FC<Props> = ({ theme = 'light', sort = 'desc' }) => {
   }, [paused, getHar]);
 
   const requestsInfo = useMemo(() => {
-    return requests.map((r) => r.toRow());
-  }, [requests]);
+    return sortRequests(requests, sort).map((r) => r.toRow());
+  }, [sort, requests]);
 
   return (
     <ThemeContext.Provider value={theme}>

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,0 +1,3 @@
+// StartNetworkLoggingOptions
+export const LOGGER_MAX_REQUESTS: number = 500;
+export const LOGGER_REFRESH_RATE: number = 50;

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,11 @@ export type StartNetworkLoggingOptions = {
    * e.g. a dev/debuging program
    */
   forceEnable?: boolean;
+  /**
+   * Refresh rate of the logger in milliseconds
+   * @default 50
+   */
+  refreshRate?: number;
 };
 
 export type NetworkRequestInfoRow = Pick<

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,17 @@
+// https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_debounce
+function debounce(func: Function, wait: number, immediate: boolean = false) {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  return function () {
+    const args = arguments;
+    clearTimeout(timeout);
+    // @ts-ignore
+    if (immediate && !timeout) func.apply(this, args);
+    timeout = setTimeout(function () {
+      timeout = undefined;
+      // @ts-ignore
+      if (!immediate) func.apply(this, args);
+    }, wait);
+  };
+}
+
+export default debounce;


### PR DESCRIPTION
If you click rapidly on make requests in the example, you will find out that the app freezes (even if the logger is paused). The amount of re-render is just crazy for the setCallback subscriber in NetworkLogger. 

- I added a `refreshRate` to debounce the callback, so the subscriber do not get 50 events in the same milisecond, default to 50milliseconds. This option was added to StartNetworkLoggingOptions
- I added a `updatedAt` property on the Request class, so you can publish through the callback only when requests are being updated or added, clearing the requests array will reset the `latestRequestUpdatedAt` to `0`
- I spreaded the array before sending it through the callback to prevent mutation of requests for all subscribers

##### before (i clicked like 30 times on pause -- not responding)
[before](https://github.com/alexbrazier/react-native-network-logger/assets/23088305/d8fc3fb3-ebdd-4719-b259-9a3cbd1684e5)

##### after
[after](https://github.com/alexbrazier/react-native-network-logger/assets/23088305/85f54d03-bc4b-46d6-ab48-bfcd0cca8dd2)