### PR TITLE
Added maxRows to NetworkLogger

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -91,7 +91,7 @@ export default function App() {
         <View style={styles.navButton} />
       </View>
       {(unmountNetworkLogger && remountButton) || (
-        <NetworkLogger theme={theme} />
+        <NetworkLogger theme={theme} maxRows={10} />
       )}
       <View style={styles.bottomView}>
         <Button

--- a/src/components/NetworkLogger.spec.tsx
+++ b/src/components/NetworkLogger.spec.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import NetworkLogger, { NetworkLoggerProps } from './NetworkLogger';
+import logger from '../loggerSingleton';
+import NetworkRequestInfo from '../NetworkRequestInfo';
+
+jest.mock('react-native/Libraries/Blob/FileReader', () => ({}));
+jest.mock('react-native/Libraries/Network/XHRInterceptor', () => ({
+  isInterceptorEnabled: jest.fn(),
+  setOpenCallback: jest.fn(),
+  setRequestHeaderCallback: jest.fn(),
+  setSendCallback: jest.fn(),
+  setHeaderReceivedCallback: jest.fn(),
+  setResponseCallback: jest.fn(),
+  enableInterception: jest.fn(),
+}));
+
+const MyNetworkLogger = (props: NetworkLoggerProps) => {
+  return <NetworkLogger {...props} />;
+};
+
+describe('max rows', () => {
+  it('should stop adding new rows once maxRows is reached', () => {
+    const requests = [] as NetworkRequestInfo[];
+    const spyOnLoggerSetCallback = jest.spyOn(logger, 'setCallback');
+    const emitCallback = jest.fn();
+    spyOnLoggerSetCallback.mockImplementation((callback) => {
+      return emitCallback.mockImplementation((id: number) => {
+        requests.unshift(
+          new NetworkRequestInfo(
+            `${id}`,
+            'XMLHttpRequest',
+            'POST',
+            `http://example.com/${id}`
+          )
+        );
+        return callback(requests);
+      });
+    });
+
+    const { queryAllByText, queryByText } = render(
+      <MyNetworkLogger maxRows={2} />
+    );
+
+    act(() => {
+      emitCallback(1);
+    });
+
+    expect(queryAllByText(/example\.com/i)).toHaveLength(1);
+
+    act(() => {
+      emitCallback(2);
+    });
+
+    expect(queryAllByText(/example\.com/i)).toHaveLength(2);
+
+    act(() => {
+      emitCallback(3);
+    });
+
+    expect(queryAllByText(/example\.com/i)).not.toHaveLength(3);
+    expect(queryByText(/example\.com\/3$/i)).toBeTruthy();
+    expect(queryByText(/example\.com\/2$/i)).toBeTruthy();
+    expect(queryByText(/example\.com\/1$/i)).toBeFalsy();
+
+    spyOnLoggerSetCallback.mockRestore();
+  });
+});
+
+describe('options', () => {
+  it('should toggle the display of the paused banner when paused', () => {
+    const { getByText, queryByText, getByTestId } = render(<MyNetworkLogger />);
+
+    fireEvent.press(getByTestId('options-menu'));
+    fireEvent.press(getByText(/^pause$/i));
+
+    expect(queryByText(/^paused$/i)).toBeTruthy();
+
+    fireEvent.press(getByTestId('options-menu'));
+    fireEvent.press(getByText(/^resume$/i));
+
+    expect(queryByText(/^paused$/i)).toBeFalsy();
+  });
+
+  it('should clear the logs on demand', () => {
+    const spyOnLoggerGetRequests = jest
+      .spyOn(logger, 'getRequests')
+      .mockImplementation(() => [
+        new NetworkRequestInfo(
+          '123',
+          'XMLHttpRequest',
+          'POST',
+          'http://example.com/1'
+        ),
+      ]);
+
+    const { getByText, queryByText, getByTestId } = render(<MyNetworkLogger />);
+
+    expect(queryByText(/^post$/i)).toBeTruthy();
+
+    fireEvent.press(getByTestId('options-menu'));
+    fireEvent.press(getByText(/^clear/i));
+
+    expect(spyOnLoggerGetRequests).toHaveBeenCalled();
+    expect(queryByText(/^post$/i)).toBeFalsy();
+
+    spyOnLoggerGetRequests.mockRestore();
+  });
+});

--- a/src/components/NetworkLogger.spec.tsx
+++ b/src/components/NetworkLogger.spec.tsx
@@ -83,27 +83,16 @@ describe('options', () => {
   });
 
   it('should clear the logs on demand', () => {
-    const spyOnLoggerGetRequests = jest
-      .spyOn(logger, 'getRequests')
-      .mockImplementation(() => [
-        new NetworkRequestInfo(
-          '123',
-          'XMLHttpRequest',
-          'POST',
-          'http://example.com/1'
-        ),
-      ]);
+    const spyOnLoggerClearRequests = jest.spyOn(logger, 'clearRequests');
 
-    const { getByText, queryByText, getByTestId } = render(<MyNetworkLogger />);
-
-    expect(queryByText(/^post$/i)).toBeTruthy();
+    const { getByText, getByTestId } = render(<MyNetworkLogger />);
+    expect(spyOnLoggerClearRequests).toHaveBeenCalledTimes(0);
 
     fireEvent.press(getByTestId('options-menu'));
     fireEvent.press(getByText(/^clear/i));
 
-    expect(spyOnLoggerGetRequests).toHaveBeenCalled();
-    expect(queryByText(/^post$/i)).toBeFalsy();
+    expect(spyOnLoggerClearRequests).toHaveBeenCalledTimes(1);
 
-    spyOnLoggerGetRequests.mockRestore();
+    spyOnLoggerClearRequests.mockRestore();
   });
 });

--- a/src/components/NetworkLogger.tsx
+++ b/src/components/NetworkLogger.tsx
@@ -13,6 +13,7 @@ import Unmounted from './Unmounted';
 interface Props {
   theme?: ThemeName | DeepPartial<Theme>;
   sort?: 'asc' | 'desc';
+  maxRows?: number;
 }
 
 const sortRequests = (requests: NetworkRequestInfo[], sort: 'asc' | 'desc') => {
@@ -22,7 +23,11 @@ const sortRequests = (requests: NetworkRequestInfo[], sort: 'asc' | 'desc') => {
   return [...requests];
 };
 
-const NetworkLogger: React.FC<Props> = ({ theme = 'light', sort = 'desc' }) => {
+const NetworkLogger: React.FC<Props> = ({
+  theme = 'light',
+  sort = 'desc',
+  maxRows,
+}) => {
   const [requests, setRequests] = useState(
     sortRequests(logger.getRequests(), sort)
   );
@@ -132,6 +137,7 @@ const NetworkLogger: React.FC<Props> = ({ theme = 'light', sort = 'desc' }) => {
                 requestsInfo={requestsInfo}
                 options={options}
                 showDetails={showDetails && !!request}
+                maxRows={maxRows ?? requests.length}
                 onPressItem={(id) => {
                   setRequest(requests.find((r) => r.id === id));
                   setShowDetails(true);
@@ -159,4 +165,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default NetworkLogger;
+export { NetworkLogger as default, Props as NetworkLoggerProps };

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -29,6 +29,7 @@ const Options: React.FC<Props> = ({ options }) => {
         <Image
           source={require('./images/more.png')}
           resizeMode="contain"
+          testID="options-menu"
           style={[styles.icon, styles.iconButton]}
         />
       </TouchableOpacity>
@@ -48,8 +49,8 @@ const Options: React.FC<Props> = ({ options }) => {
             {options.map(({ text, onPress }) => (
               <Button
                 key={text}
-                onPress={async () => {
-                  await onPress();
+                onPress={() => {
+                  onPress();
                   setOpenOptions(false);
                 }}
               >

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -49,8 +49,8 @@ const Options: React.FC<Props> = ({ options }) => {
             {options.map(({ text, onPress }) => (
               <Button
                 key={text}
-                onPress={() => {
-                  onPress();
+                onPress={async () => {
+                  await onPress();
                   setOpenOptions(false);
                 }}
               >

--- a/src/components/RequestList.tsx
+++ b/src/components/RequestList.tsx
@@ -11,6 +11,7 @@ interface Props {
   onPressItem: (item: NetworkRequestInfo['id']) => void;
   options: { text: string; onPress: () => void }[];
   showDetails: boolean;
+  maxRows: number;
 }
 
 const RequestList: React.FC<Props> = ({
@@ -18,20 +19,23 @@ const RequestList: React.FC<Props> = ({
   onPressItem,
   options,
   showDetails,
+  maxRows,
 }) => {
   const styles = useThemedStyles(themedStyles);
 
   const [searchValue, onChangeSearchText] = useState('');
 
   const filteredRequests = useMemo(() => {
-    return requestsInfo.filter((request) => {
-      const value = searchValue.toLowerCase().trim();
-      return (
-        request.url.toLowerCase().includes(value) ||
-        request.gqlOperation?.toLowerCase().includes(value)
-      );
-    });
-  }, [requestsInfo, searchValue]);
+    return requestsInfo
+      .filter((request) => {
+        const value = searchValue.toLowerCase().trim();
+        return (
+          request.url.toLowerCase().includes(value) ||
+          request.gqlOperation?.toLowerCase().includes(value)
+        );
+      })
+      .slice(0, maxRows);
+  }, [requestsInfo, maxRows, searchValue]);
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
To limit the amount of data passed to NetworkLogger child components and prevent re-rendering too much data, we can now pass `maxRows` to NetworkLogger

compared to `maxRequests` which pop() the last one to prevent recording more than the max. `maxRows` is only visual, the request won't be lost if it is kept inside the main logger.

when the logger has 500 requests, then it gets pretty slow, so this prop saves the day