### PR TITLE
Compact vs regular rows

### DIFF
--- a/global-jest-setup.js
+++ b/global-jest-setup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+  process.env.TZ = 'UTC';
+};

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "!**/__mocks__"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "TZ=UTC jest",
     "typescript": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "prettier": "prettier --check '{,example/}src/**/*.{js,json,ts,tsx}' '{*,example/*}.{js,ts,tsx}'",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "!**/__mocks__"
   ],
   "scripts": {
-    "test": "TZ=UTC jest",
+    "test": "jest",
     "typescript": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "prettier": "prettier --check '{,example/}src/**/*.{js,json,ts,tsx}' '{*,example/*}.{js,ts,tsx}'",
@@ -79,7 +79,8 @@
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules",
       "<rootDir>/lib/"
-    ]
+    ],
+    "globalSetup": "<rootDir>/global-jest-setup.js"
   },
   "husky": {
     "hooks": {

--- a/src/components/NetworkLogger.spec.tsx
+++ b/src/components/NetworkLogger.spec.tsx
@@ -40,28 +40,17 @@ describe('options', () => {
   });
 
   it('should clear the logs on demand', () => {
-    const spyOnLoggerGetRequests = jest
-      .spyOn(logger, 'getRequests')
-      .mockImplementation(() => [
-        new NetworkRequestInfo(
-          '123',
-          'XMLHttpRequest',
-          'POST',
-          'http://example.com/1'
-        ),
-      ]);
+    const spyOnLoggerClearRequests = jest.spyOn(logger, 'clearRequests');
 
-    const { getByText, queryByText, getByTestId } = render(<MyNetworkLogger />);
-
-    expect(queryByText(/^post$/i)).toBeTruthy();
+    const { getByText, getByTestId } = render(<MyNetworkLogger />);
+    expect(spyOnLoggerClearRequests).toHaveBeenCalledTimes(0);
 
     fireEvent.press(getByTestId('options-menu'));
     fireEvent.press(getByText(/^clear/i));
 
-    expect(spyOnLoggerGetRequests).toHaveBeenCalled();
-    expect(queryByText(/^post$/i)).toBeFalsy();
+    expect(spyOnLoggerClearRequests).toHaveBeenCalledTimes(1);
 
-    spyOnLoggerGetRequests.mockRestore();
+    spyOnLoggerClearRequests.mockRestore();
   });
 });
 

--- a/src/components/NetworkLogger.spec.tsx
+++ b/src/components/NetworkLogger.spec.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import {
+  render,
+  fireEvent,
+  within,
+  screen,
+} from '@testing-library/react-native';
+import NetworkLogger, { NetworkLoggerProps } from './NetworkLogger';
+import logger from '../loggerSingleton';
+import NetworkRequestInfo from '../NetworkRequestInfo';
+
+jest.mock('react-native/Libraries/Blob/FileReader', () => ({}));
+jest.mock('react-native/Libraries/Network/XHRInterceptor', () => ({
+  isInterceptorEnabled: jest.fn(),
+  setOpenCallback: jest.fn(),
+  setRequestHeaderCallback: jest.fn(),
+  setSendCallback: jest.fn(),
+  setHeaderReceivedCallback: jest.fn(),
+  setResponseCallback: jest.fn(),
+  enableInterception: jest.fn(),
+}));
+
+const MyNetworkLogger = (props: NetworkLoggerProps) => {
+  return <NetworkLogger {...props} />;
+};
+
+describe('options', () => {
+  it('should toggle the display of the paused banner when paused', () => {
+    const { getByText, queryByText, getByTestId } = render(<MyNetworkLogger />);
+
+    fireEvent.press(getByTestId('options-menu'));
+    fireEvent.press(getByText(/^pause$/i));
+
+    expect(queryByText(/^paused$/i)).toBeTruthy();
+
+    fireEvent.press(getByTestId('options-menu'));
+    fireEvent.press(getByText(/^resume$/i));
+
+    expect(queryByText(/^paused$/i)).toBeFalsy();
+  });
+
+  it('should clear the logs on demand', () => {
+    const spyOnLoggerGetRequests = jest
+      .spyOn(logger, 'getRequests')
+      .mockImplementation(() => [
+        new NetworkRequestInfo(
+          '123',
+          'XMLHttpRequest',
+          'POST',
+          'http://example.com/1'
+        ),
+      ]);
+
+    const { getByText, queryByText, getByTestId } = render(<MyNetworkLogger />);
+
+    expect(queryByText(/^post$/i)).toBeTruthy();
+
+    fireEvent.press(getByTestId('options-menu'));
+    fireEvent.press(getByText(/^clear/i));
+
+    expect(spyOnLoggerGetRequests).toHaveBeenCalled();
+    expect(queryByText(/^post$/i)).toBeFalsy();
+
+    spyOnLoggerGetRequests.mockRestore();
+  });
+});
+
+describe('regular vs compact row', () => {
+  it.each([true, false])('should render the row compact: %p', (compact) => {
+    const spyOnLoggerGetRequests = jest
+      .spyOn(logger, 'getRequests')
+      .mockImplementation(() => {
+        const request = new NetworkRequestInfo(
+          '123',
+          'XMLHttpRequest',
+          'POST',
+          'http://example.com/1'
+        );
+        request.startTime = new Date('2000-01-01T12:34:00.000Z').getTime();
+        request.endTime = new Date('2000-01-01T12:34:56.789Z').getTime();
+        request.status = 200;
+        return [request];
+      });
+
+    const { getByText } = render(<MyNetworkLogger compact={compact} />);
+    screen.debug();
+    const method = getByText(/^post$/i);
+    expect(method).toBeTruthy();
+    expect(!!within(method.parent!.parent!).queryByText(/^12:34:00$/i)).toBe(
+      compact
+    );
+
+    const status = getByText(/^200$/i);
+    expect(status).toBeTruthy();
+    expect(
+      within(status.parent!.parent!).queryByText(/^56789ms$/i)
+    ).toBeTruthy();
+    expect(within(status.parent!.parent!).queryByText(/^12:34:00$/i)).not.toBe(
+      compact
+    );
+
+    spyOnLoggerGetRequests.mockRestore();
+  });
+});

--- a/src/components/NetworkLogger.spec.tsx
+++ b/src/components/NetworkLogger.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { fireEvent, render, within } from '@testing-library/react-native';
+import { act, fireEvent, render, within } from '@testing-library/react-native';
 import NetworkLogger, { NetworkLoggerProps } from './NetworkLogger';
 import logger from '../loggerSingleton';
 import NetworkRequestInfo from '../NetworkRequestInfo';
@@ -100,11 +100,23 @@ describe('options', () => {
 
 describe('regular vs compact row', () => {
   it.each([true, false])('should render the row compact: %p', (compact) => {
-    const spyOnLoggerGetRequests = jest
-      .spyOn(logger, 'getRequests')
-      .mockImplementation(() => {
+    const requests = [] as NetworkRequestInfo[];
+    const spyOnLoggerSetCallback = jest.spyOn(logger, 'setCallback');
+    const emitCallback = jest.fn();
+    spyOnLoggerSetCallback.mockImplementation((callback) => {
+      return emitCallback.mockImplementation((id: number) => {
+        if (id !== 1) {
+          const request = new NetworkRequestInfo(
+            `${id}`,
+            'XMLHttpRequest',
+            'GET',
+            `http://example.com/${id}`
+          );
+          requests.unshift(request);
+          return callback(requests);
+        }
         const request = new NetworkRequestInfo(
-          '123',
+          '1',
           'XMLHttpRequest',
           'POST',
           'http://example.com/1'
@@ -112,11 +124,17 @@ describe('regular vs compact row', () => {
         request.startTime = new Date('2000-01-01T12:34:00.000Z').getTime();
         request.endTime = new Date('2000-01-01T12:34:56.789Z').getTime();
         request.status = 200;
-        return [request];
+        requests.unshift(request);
+        return callback(requests);
       });
+    });
 
     const { getByText } = render(<MyNetworkLogger compact={compact} />);
-    
+
+    act(() => {
+      emitCallback(1);
+    });
+
     const method = getByText(/^post$/i);
     expect(method).toBeTruthy();
     expect(!!within(method.parent!.parent!).queryByText(/^12:34:00$/i)).toBe(
@@ -132,6 +150,6 @@ describe('regular vs compact row', () => {
       compact
     );
 
-    spyOnLoggerGetRequests.mockRestore();
+    spyOnLoggerSetCallback.mockRestore();
   });
 });

--- a/src/components/NetworkLogger.tsx
+++ b/src/components/NetworkLogger.tsx
@@ -13,6 +13,7 @@ import Unmounted from './Unmounted';
 interface Props {
   theme?: ThemeName | DeepPartial<Theme>;
   sort?: 'asc' | 'desc';
+  compact?: boolean;
 }
 
 const sortRequests = (requests: NetworkRequestInfo[], sort: 'asc' | 'desc') => {
@@ -22,7 +23,11 @@ const sortRequests = (requests: NetworkRequestInfo[], sort: 'asc' | 'desc') => {
   return [...requests];
 };
 
-const NetworkLogger: React.FC<Props> = ({ theme = 'light', sort = 'desc' }) => {
+const NetworkLogger: React.FC<Props> = ({
+  theme = 'light',
+  sort = 'desc',
+  compact = false,
+}) => {
   const [requests, setRequests] = useState(
     sortRequests(logger.getRequests(), sort)
   );
@@ -129,6 +134,7 @@ const NetworkLogger: React.FC<Props> = ({ theme = 'light', sort = 'desc' }) => {
                 </View>
               )}
               <RequestList
+                compact={compact}
                 requestsInfo={requestsInfo}
                 options={options}
                 showDetails={showDetails && !!request}
@@ -159,4 +165,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default NetworkLogger;
+export { NetworkLogger as default, Props as NetworkLoggerProps };

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -29,6 +29,7 @@ const Options: React.FC<Props> = ({ options }) => {
         <Image
           source={require('./images/more.png')}
           resizeMode="contain"
+          testID="options-menu"
           style={[styles.icon, styles.iconButton]}
         />
       </TouchableOpacity>
@@ -48,8 +49,8 @@ const Options: React.FC<Props> = ({ options }) => {
             {options.map(({ text, onPress }) => (
               <Button
                 key={text}
-                onPress={async () => {
-                  await onPress();
+                onPress={() => {
+                  onPress();
                   setOpenOptions(false);
                 }}
               >

--- a/src/components/RequestList.tsx
+++ b/src/components/RequestList.tsx
@@ -11,6 +11,7 @@ interface Props {
   onPressItem: (item: NetworkRequestInfo['id']) => void;
   options: { text: string; onPress: () => void }[];
   showDetails: boolean;
+  compact: boolean;
 }
 
 const RequestList: React.FC<Props> = ({
@@ -18,6 +19,7 @@ const RequestList: React.FC<Props> = ({
   onPressItem,
   options,
   showDetails,
+  compact,
 }) => {
   const styles = useThemedStyles(themedStyles);
 
@@ -46,7 +48,11 @@ const RequestList: React.FC<Props> = ({
         keyExtractor={(item) => item.id}
         data={filteredRequests}
         renderItem={({ item }) => (
-          <ResultItem request={item} onPress={() => onPressItem(item.id)} />
+          <ResultItem
+            request={item}
+            onPress={() => onPressItem(item.id)}
+            compact={compact}
+          />
         )}
       />
     </View>

--- a/src/components/ResultItem.tsx
+++ b/src/components/ResultItem.tsx
@@ -8,9 +8,10 @@ interface Props {
   request: NetworkRequestInfoRow;
   onPress?(): void;
   style?: any;
+  compact?: boolean;
 }
 
-const ResultItem: React.FC<Props> = ({ style, request, onPress }) => {
+const ResultItem: React.FC<Props> = ({ style, request, onPress, compact }) => {
   const styles = useThemedStyles(themedStyles);
   const theme = useTheme();
   const onDetailsPage = !onPress;
@@ -47,6 +48,7 @@ const ResultItem: React.FC<Props> = ({ style, request, onPress }) => {
   const pad = (num: number) => `0${num}`.slice(-2);
 
   const getTime = (time: number) => {
+    if (time === 0) return '';
     const date = new Date(time);
     const hours = pad(date.getHours());
     const minutes = pad(date.getMinutes());
@@ -62,23 +64,34 @@ const ResultItem: React.FC<Props> = ({ style, request, onPress }) => {
       style={[styles.container, style]}
       {...(onPress && { accessibilityRole: 'button', onPress })}
     >
-      <View style={styles.leftContainer}>
-        <Text
-          style={[styles.text, styles.method]}
-          accessibilityLabel={`Method: ${request.method}`}
-        >
-          {request.method}
-        </Text>
-        <Text
-          style={[styles.status, getStatusStyles(request.status)]}
-          accessibilityLabel={`Response status ${status}`}
-        >
-          {status}
-        </Text>
-        <Text style={styles.text}>
-          {request.duration > 0 ? `${request.duration}ms` : 'pending'}
-        </Text>
-        <Text style={styles.time}>{getTime(request.startTime)}</Text>
+      <View
+        style={compact ? styles.leftContainerCompact : styles.leftContainer}
+      >
+        <View style={styles.leftContainerSplit}>
+          <Text
+            style={[styles.text, styles.method]}
+            accessibilityLabel={`Method: ${request.method}`}
+          >
+            {request.method}
+          </Text>
+          {compact && (
+            <Text style={styles.time}>{getTime(request.startTime)}</Text>
+          )}
+        </View>
+        <View style={styles.leftContainerSplit}>
+          <Text
+            style={[styles.status, getStatusStyles(request.status)]}
+            accessibilityLabel={`Response status ${status}`}
+          >
+            {status}
+          </Text>
+          <Text style={styles.time}>
+            {request.duration > 0 ? `${request.duration}ms` : 'pending'}
+          </Text>
+          {!compact && (
+            <Text style={styles.time}>{getTime(request.startTime)}</Text>
+          )}
+        </View>
       </View>
       <View style={[styles.content]}>
         <Text
@@ -116,6 +129,13 @@ const themedStyles = (theme: Theme) =>
     },
     leftContainer: {
       flexDirection: 'column',
+      alignItems: 'center',
+    },
+    leftContainerCompact: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    leftContainerSplit: {
       alignItems: 'center',
     },
     status: {
@@ -156,8 +176,8 @@ const themedStyles = (theme: Theme) =>
       backgroundColor: theme.colors.secondary,
       borderRadius: 10,
       alignSelf: 'flex-start',
-      padding: 5,
-      marginTop: 5,
+      padding: 4,
+      marginTop: 4,
     },
     gqlText: {
       color: theme.colors.onSecondary,


### PR DESCRIPTION
added a prop to NetworkLogger component

```
<NetworkLogger compact />
```

note: unit tests will run with `TZ=UTC` flag enabled, so all Date will be formatted as UTC. It was needed to test the startTime `00:00:00` UTC was changed to local time

| regular | compact | 
| ---- | ---- |
| ![image](https://github.com/alexbrazier/react-native-network-logger/assets/23088305/896f6f45-93f7-451e-8040-ac04d2a5f92c) |  ![image](https://github.com/alexbrazier/react-native-network-logger/assets/23088305/dbe2789a-e7ec-4d16-aa6e-9e49e9a9dade) |