### PR TITLE
Disable the singleton logger

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   StyleSheet,
   Button,
@@ -13,6 +13,7 @@ import NetworkLogger, {
   ThemeName,
   getBackHandler,
   startNetworkLogging,
+  stopNetworkLogging,
 } from 'react-native-network-logger';
 import { getRates } from './apolloClient';
 
@@ -47,19 +48,31 @@ export default function App() {
     // fetch('https://failingrequest');
   };
 
-  startNetworkLogging({
-    ignoredHosts: ['192.168.1.28', '127.0.0.1'],
-    maxRequests: 500,
-    ignoredUrls: ['https://httpstat.us/other'],
-    ignoredPatterns: [/^POST http:\/\/(192|10)/],
-  });
+  const start = useCallback(() => {
+    startNetworkLogging({
+      ignoredHosts: ['192.168.1.28', '127.0.0.1'],
+      maxRequests: 500,
+      ignoredUrls: ['https://httpstat.us/other'],
+      ignoredPatterns: [/^POST http:\/\/(192|10)/],
+    });
+  }, []);
+
+  useEffect(() => {
+    start();
+    return () => {
+      stopNetworkLogging();
+    };
+  }, [start]);
 
   const [theme, setTheme] = useState<ThemeName>('dark');
   const isDark = theme === 'dark';
 
   const styles = themedStyles(isDark);
 
-  const goBack = () => setUnmountNetworkLogger(true);
+  const goBack = () => {
+    stopNetworkLogging();
+    setUnmountNetworkLogger(true);
+  };
 
   const [unmountNetworkLogger, setUnmountNetworkLogger] = useState(false);
 
@@ -69,7 +82,10 @@ export default function App() {
     <View>
       <Button
         title={'Re-open the network logger'}
-        onPress={() => setUnmountNetworkLogger(false)}
+        onPress={() => {
+          setUnmountNetworkLogger(false);
+          start();
+        }}
       />
     </View>
   );

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -59,6 +59,8 @@ export default function App() {
 
   const [unmountNetworkLogger, setUnmountNetworkLogger] = useState(false);
 
+  // note: Logger is a singleton so it starts on the first render
+  // useLayoutEffect is used to ensure the setup runs before the component mounts (useEffect is async)
   useLayoutEffect(() => {
     start();
     return () => {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useLayoutEffect, useState } from 'react';
 import {
   StyleSheet,
   Button,
@@ -50,19 +50,21 @@ export default function App() {
 
   const start = useCallback(() => {
     startNetworkLogging({
-      ignoredHosts: ['192.168.1.28', '127.0.0.1'],
+      ignoredHosts: ['127.0.0.1'],
       maxRequests: 20,
       ignoredUrls: ['https://httpstat.us/other'],
-      ignoredPatterns: [/^POST http:\/\/(192|10)/],
+      ignoredPatterns: [/^POST http:\/\/(192|10)/, /\/logs$/, /\/symbolicate$/],
     });
   }, []);
 
-  useEffect(() => {
+  const [unmountNetworkLogger, setUnmountNetworkLogger] = useState(false);
+
+  useLayoutEffect(() => {
     start();
     return () => {
       stopNetworkLogging();
     };
-  }, [start]);
+  }, [start, unmountNetworkLogger]);
 
   const [theme, setTheme] = useState<ThemeName>('dark');
   const isDark = theme === 'dark';
@@ -74,8 +76,6 @@ export default function App() {
     setUnmountNetworkLogger(true);
   };
 
-  const [unmountNetworkLogger, setUnmountNetworkLogger] = useState(false);
-
   const backHandler = getBackHandler(goBack);
 
   const remountButton = (
@@ -84,7 +84,6 @@ export default function App() {
         title={'Re-open the network logger'}
         onPress={() => {
           setUnmountNetworkLogger(false);
-          start();
         }}
       />
     </View>
@@ -96,6 +95,7 @@ export default function App() {
       <View style={styles.header}>
         <TouchableOpacity
           style={styles.navButton}
+          testID="backButton"
           onPress={backHandler}
           hitSlop={{ top: 20, left: 20, bottom: 20, right: 20 }}
         >

--- a/module.d.ts
+++ b/module.d.ts
@@ -1,3 +1,4 @@
+// https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Network/XHRInterceptor.js
 declare module 'react-native/Libraries/Network/XHRInterceptor' {
   export function isInterceptorEnabled(): boolean;
   export function setOpenCallback(...props: any): void;
@@ -6,6 +7,7 @@ declare module 'react-native/Libraries/Network/XHRInterceptor' {
   export function setHeaderReceivedCallback(...props: any): void;
   export function setResponseCallback(...props: any): void;
   export function enableInterception(): void;
+  export function disableInterception(): void;
 }
 
 declare module 'react-native/Libraries/Blob/FileReader' {

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -210,6 +210,8 @@ export default class Logger {
   };
 
   disableXHRInterception = () => {
+    if (!this.enabled) return;
+
     this.clearRequests();
 
     nextXHRId = 0;

--- a/src/__tests__/Logger.spec.ts
+++ b/src/__tests__/Logger.spec.ts
@@ -25,7 +25,7 @@ beforeEach(() => {
 
 describe('enableXHRInterception', () => {
   it('should do nothing if interceptor has already been enabled', () => {
-    (warn as jest.Mock).mockImplementationOnce(() => { });
+    (warn as jest.Mock).mockImplementationOnce(() => {});
     const logger = new Logger();
 
     (XHRInterceptor.isInterceptorEnabled as jest.Mock).mockReturnValueOnce(

--- a/src/__tests__/Logger.spec.ts
+++ b/src/__tests__/Logger.spec.ts
@@ -1,6 +1,7 @@
 import XHRInterceptor from 'react-native/Libraries/Network/XHRInterceptor';
 import { warn } from '../utils/logger';
 import Logger from '../Logger';
+import { LOGGER_MAX_REQUESTS } from '../constant';
 
 jest.mock('react-native/Libraries/Blob/FileReader', () => ({}));
 jest.mock('react-native/Libraries/Network/XHRInterceptor', () => ({
@@ -11,6 +12,7 @@ jest.mock('react-native/Libraries/Network/XHRInterceptor', () => ({
   setHeaderReceivedCallback: jest.fn(),
   setResponseCallback: jest.fn(),
   enableInterception: jest.fn(),
+  disableInterception: jest.fn(),
 }));
 
 jest.mock('../utils/logger', () => ({
@@ -155,6 +157,72 @@ describe('enableXHRInterception', () => {
   });
 });
 
+describe('disableXHRInterception', () => {
+  it('should do nothing if interceptor has not been enabled', () => {
+    const logger = new Logger();
+
+    (XHRInterceptor.isInterceptorEnabled as jest.Mock).mockReturnValueOnce(
+      false
+    );
+
+    const result = logger.disableXHRInterception();
+
+    expect(result).toBeUndefined();
+    expect(XHRInterceptor.isInterceptorEnabled).toHaveBeenCalledTimes(0);
+    expect(XHRInterceptor.disableInterception).toHaveBeenCalledTimes(0);
+  });
+
+  it('should call disableInterception and clear options', () => {
+    const logger = new Logger();
+
+    logger.enableXHRInterception();
+    logger.disableXHRInterception();
+
+    expect(XHRInterceptor.disableInterception).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.disableInterception).toHaveBeenCalledWith();
+
+    // @ts-ignore
+    expect(logger.ignoredHosts).toBeUndefined();
+    // @ts-ignore
+    expect(logger.ignoredUrls).toBeUndefined();
+    // @ts-ignore
+    expect(logger.ignoredPatterns).toBeUndefined();
+    // @ts-ignore
+    expect(logger.maxRequests).toEqual(LOGGER_MAX_REQUESTS);
+    // @ts-ignore
+    expect(logger.requests).toEqual([]);
+    // @ts-ignore
+    expect(logger.xhrIdMap).toEqual(new Map());
+  });
+
+  it('should set options after re-enabling', () => {
+    const logger = new Logger();
+
+    logger.enableXHRInterception({
+      ignoredHosts: ['example.com'],
+      ignoredUrls: ['http://example.com/'],
+      ignoredPatterns: [/^POST /],
+      maxRequests: 100,
+    });
+    logger.disableXHRInterception();
+    logger.enableXHRInterception({
+      ignoredHosts: ['test.com'],
+      ignoredUrls: ['http://test.com/'],
+      ignoredPatterns: [/^HEAD /],
+      maxRequests: 10,
+    });
+
+    // @ts-ignore
+    expect(logger.ignoredHosts).toStrictEqual(new Set(['test.com']));
+    // @ts-ignore
+    expect(logger.ignoredUrls).toStrictEqual(new Set(['http://test.com/']));
+    // @ts-ignore
+    expect(logger.ignoredPatterns).toStrictEqual([/^HEAD /]);
+    // @ts-ignore
+    expect(logger.maxRequests).toEqual(10);
+  });
+});
+
 describe('getRequests', () => {
   it('should return the requests', () => {
     const logger = new Logger();
@@ -242,8 +310,7 @@ describe('openCallback', () => {
     expect(logger.getRequests()[0].url).toEqual(url2);
     expect(logger.getRequests()[1].url).toEqual(url1);
 
-    // @ts-expect-error
-    logger.dispose();
+    logger.disableXHRInterception();
   });
 
   it('should ignore requests that have ignored hosts', () => {
@@ -261,8 +328,7 @@ describe('openCallback', () => {
     expect(logger.getRequests()[0].url).toEqual(url1);
     expect(logger.getRequests()).toHaveLength(1);
 
-    // @ts-expect-error
-    logger.dispose();
+    logger.disableXHRInterception();
   });
 
   it('should ignore requests that have ignored urls', () => {
@@ -279,8 +345,7 @@ describe('openCallback', () => {
     expect(logger.getRequests()[0].url).toEqual(url1);
     expect(logger.getRequests()).toHaveLength(1);
 
-    // @ts-expect-error
-    logger.dispose();
+    logger.disableXHRInterception();
   });
 
   it('should ignore requests that match pattern', () => {
@@ -307,8 +372,7 @@ describe('openCallback', () => {
     expect(logger.getRequests()[0].method).toEqual('PUT');
     expect(logger.getRequests()).toHaveLength(2);
 
-    // @ts-expect-error
-    logger.dispose();
+    logger.disableXHRInterception();
   });
 
   it('should retrieve requests when it is restricted by maxRequests', () => {
@@ -339,7 +403,6 @@ describe('openCallback', () => {
     // @ts-expect-error
     expect(logger.getRequest(3)?.method).toBe(first?.method);
 
-    // @ts-expect-error
-    logger.dispose();
+    logger.disableXHRInterception();
   });
 });

--- a/src/__tests__/Logger.spec.ts
+++ b/src/__tests__/Logger.spec.ts
@@ -25,7 +25,7 @@ beforeEach(() => {
 
 describe('enableXHRInterception', () => {
   it('should do nothing if interceptor has already been enabled', () => {
-    (warn as jest.Mock).mockImplementationOnce(() => {});
+    (warn as jest.Mock).mockImplementationOnce(() => { });
     const logger = new Logger();
 
     (XHRInterceptor.isInterceptorEnabled as jest.Mock).mockReturnValueOnce(

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1,0 +1,147 @@
+import XHRInterceptor from 'react-native/Libraries/Network/XHRInterceptor';
+import { startNetworkLogging, stopNetworkLogging } from '..';
+import logger from '../loggerSingleton';
+
+jest.mock('react-native/Libraries/Blob/FileReader', () => ({}));
+jest.mock('react-native/Libraries/Network/XHRInterceptor', () => ({
+  isInterceptorEnabled: jest.fn(),
+  setOpenCallback: jest.fn(),
+  setRequestHeaderCallback: jest.fn(),
+  setSendCallback: jest.fn(),
+  setHeaderReceivedCallback: jest.fn(),
+  setResponseCallback: jest.fn(),
+  enableInterception: jest.fn(),
+  disableInterception: jest.fn(),
+}));
+
+describe('singleton logger', () => {
+  afterEach(() => {
+    logger.disableXHRInterception();
+    jest.resetAllMocks();
+  });
+  it('should set options when starting the logger', () => {
+    (XHRInterceptor.isInterceptorEnabled as jest.Mock).mockReturnValueOnce(
+      false
+    );
+    expect(logger.enabled).toBe(false);
+
+    startNetworkLogging({
+      maxRequests: 23,
+      ignoredHosts: ['foo'],
+      ignoredUrls: ['bar'],
+      ignoredPatterns: [/baz/],
+    });
+
+    // @ts-ignore
+    expect(logger.maxRequests).toBe(23);
+    // @ts-ignore
+    expect(logger.ignoredHosts).toEqual(new Set(['foo']));
+    // @ts-ignore
+    expect(logger.ignoredUrls).toEqual(new Set(['bar']));
+    // @ts-ignore
+    expect(logger.ignoredPatterns).toEqual([/baz/]);
+    expect(XHRInterceptor.isInterceptorEnabled).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.setOpenCallback).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.setRequestHeaderCallback).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.setHeaderReceivedCallback).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.setSendCallback).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.setResponseCallback).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.enableInterception).toHaveBeenCalledTimes(1);
+    expect(logger.enabled).toBe(true);
+  });
+
+  it('should not start twice the logger', () => {
+    (XHRInterceptor.isInterceptorEnabled as jest.Mock).mockReturnValueOnce(
+      false
+    );
+    expect(logger.enabled).toBe(false);
+
+    startNetworkLogging();
+
+    expect(XHRInterceptor.isInterceptorEnabled).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.setOpenCallback).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.setRequestHeaderCallback).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.setHeaderReceivedCallback).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.setSendCallback).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.setResponseCallback).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.enableInterception).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.disableInterception).toHaveBeenCalledTimes(0);
+    expect(logger.enabled).toBe(true);
+
+    startNetworkLogging();
+
+    expect(XHRInterceptor.isInterceptorEnabled).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.setOpenCallback).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.setRequestHeaderCallback).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.setHeaderReceivedCallback).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.setSendCallback).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.setResponseCallback).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.enableInterception).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.disableInterception).toHaveBeenCalledTimes(0);
+    expect(logger.enabled).toBe(true);
+  });
+
+  it('should stop the logger', () => {
+    (XHRInterceptor.isInterceptorEnabled as jest.Mock).mockReturnValueOnce(
+      false
+    );
+    expect(logger.enabled).toBe(false);
+
+    startNetworkLogging();
+
+    expect(XHRInterceptor.isInterceptorEnabled).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.enableInterception).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.disableInterception).toHaveBeenCalledTimes(0);
+
+    stopNetworkLogging();
+
+    expect(XHRInterceptor.isInterceptorEnabled).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.enableInterception).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.disableInterception).toHaveBeenCalledTimes(1);
+
+    expect(XHRInterceptor.setOpenCallback).toHaveBeenCalledTimes(2);
+    expect(XHRInterceptor.setRequestHeaderCallback).toHaveBeenCalledTimes(2);
+    expect(XHRInterceptor.setHeaderReceivedCallback).toHaveBeenCalledTimes(2);
+    expect(XHRInterceptor.setSendCallback).toHaveBeenCalledTimes(2);
+    expect(XHRInterceptor.setResponseCallback).toHaveBeenCalledTimes(2);
+
+    expect(logger.enabled).toBe(false);
+    expect(logger.paused).toBe(false);
+    // @ts-ignore
+    expect(logger.requests).toEqual([]);
+    // @ts-ignore
+    expect(logger.xhrIdMap).toEqual({});
+    // @ts-ignore
+    expect(logger.maxRequests).toBe(500);
+    // @ts-ignore
+    expect(logger.ignoredHosts).toBeUndefined();
+    // @ts-ignore
+    expect(logger.ignoredUrls).toBeUndefined();
+    // @ts-ignore
+    expect(logger.ignoredPatterns).toBeUndefined();
+  });
+});
+
+describe('clearRequests', () => {
+  it('should clear the requests', () => {
+    logger.callback = jest.fn();
+
+    // @ts-ignore
+    logger.requests = ['test-request'];
+
+    logger.clearRequests();
+
+    expect(logger.getRequests()).toEqual([]);
+    expect(logger.callback).toHaveBeenCalledTimes(1);
+    expect(logger.callback).toHaveBeenCalledWith([]);
+  });
+});
+
+describe('getRequests', () => {
+  it('should return the requests', () => {
+    // @ts-ignore
+    logger.requests = ['test-request'];
+
+    expect(logger.getRequests()).toEqual(['test-request']);
+  });
+});

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1,7 +1,7 @@
 import XHRInterceptor from 'react-native/Libraries/Network/XHRInterceptor';
 import { startNetworkLogging, stopNetworkLogging } from '..';
 import logger from '../loggerSingleton';
-import { LOGGER_MAX_REQUESTS } from '../constant';
+import { LOGGER_MAX_REQUESTS, LOGGER_REFRESH_RATE } from '../constant';
 
 jest.mock('react-native/Libraries/Blob/FileReader', () => ({}));
 jest.mock('react-native/Libraries/Network/XHRInterceptor', () => ({

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1,6 +1,7 @@
 import XHRInterceptor from 'react-native/Libraries/Network/XHRInterceptor';
 import { startNetworkLogging, stopNetworkLogging } from '..';
 import logger from '../loggerSingleton';
+import { LOGGER_MAX_REQUESTS } from '../constant';
 
 jest.mock('react-native/Libraries/Blob/FileReader', () => ({}));
 jest.mock('react-native/Libraries/Network/XHRInterceptor', () => ({
@@ -110,9 +111,9 @@ describe('singleton logger', () => {
     // @ts-ignore
     expect(logger.requests).toEqual([]);
     // @ts-ignore
-    expect(logger.xhrIdMap).toEqual({});
+    expect(logger.xhrIdMap).toEqual(new Map());
     // @ts-ignore
-    expect(logger.maxRequests).toBe(500);
+    expect(logger.maxRequests).toBe(LOGGER_MAX_REQUESTS);
     // @ts-ignore
     expect(logger.ignoredHosts).toBeUndefined();
     // @ts-ignore

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -125,16 +125,19 @@ describe('singleton logger', () => {
 
 describe('clearRequests', () => {
   it('should clear the requests', () => {
+    jest.useFakeTimers();
     logger.callback = jest.fn();
 
     // @ts-ignore
     logger.requests = ['test-request'];
 
     logger.clearRequests();
+    jest.advanceTimersByTime(LOGGER_REFRESH_RATE);
 
     expect(logger.getRequests()).toEqual([]);
     expect(logger.callback).toHaveBeenCalledTimes(1);
     expect(logger.callback).toHaveBeenCalledWith([]);
+    jest.useFakeTimers();
   });
 });
 

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,0 +1,2 @@
+// StartNetworkLoggingOptions
+export const LOGGER_MAX_REQUESTS: number = 500;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,10 @@ export const startNetworkLogging = (options?: StartNetworkLoggingOptions) => {
   logger.enableXHRInterception(options);
 };
 
+export const stopNetworkLogging = () => {
+  logger.disableXHRInterception();
+};
+
 export const getRequests = () => logger.getRequests();
 
 export const clearRequests = () => logger.clearRequests();

--- a/src/loggerSingleton.ts
+++ b/src/loggerSingleton.ts
@@ -1,5 +1,5 @@
 import Logger from './Logger';
 
-const logger = new Logger();
+const logger: Logger = new Logger();
 
 export default logger;


### PR DESCRIPTION
We use a feature flag the enable it, so it can be toggled (enabled/disabled), we want it to prevent tracking requests when disabled

- Added a `disableXHRInterception` function to `Logger`, can be called with `stopNetworkLogging()`
- Updated `App` to start and stop the logger when unmounting with the back button