### PR TITLE
fix: Incorrect types export 

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,4 +17,4 @@ export const clearRequests = () => logger.clearRequests();
 
 export { getBackHandler } from './backHandler';
 
-export { ThemeName, Theme } from './theme';
+export type { ThemeName, Theme } from './theme';


### PR DESCRIPTION
Exporting a type without annotation (not using `export type`) can cause some unexpected bugs. For example, when using tools like `rnx-kit` with `tree shaking` enabled, the project may fail to compile because it tries to import a non-existing type. During the `tree shaking` step, those types are removed, so using correct export annotations can help avoid these issues.