### PR TITLE
Add json viewer and update content layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,27 @@ import NetworkLogger from 'react-native-network-logger';
 const MyScreen = () => <NetworkLogger compact />;
 ```
 
+#### Initial Expansion Controls of RequestDetails component
+
+Control which sections of the RequestDetails component are expanded by default when viewing a request:
+
+```tsx
+import NetworkLogger from 'react-native-network-logger';
+
+const MyScreen = () => (
+  <NetworkLogger
+    // Headers
+    initialRequestHeadersExpanded={false}
+    initialResponseHeadersExpanded={false}
+    // Bodies
+    initialRequestBodyExpanded={false}
+    initialResponseBodyExpanded={false}
+  />
+);
+```
+
+These affect the initial expansion of the Request/Response headers and body sections in the details view.
+
 #### Force Enable
 
 If you are running another network logging interceptor, e.g. Reactotron, the logger will not start as only one can be run at once. You can override this behaviour and force the logger to start by using the `forceEnable` option.

--- a/src/components/BodyViewer.tsx
+++ b/src/components/BodyViewer.tsx
@@ -1,0 +1,276 @@
+import React, { useState, useMemo } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Platform,
+  TouchableOpacity,
+  TextInput,
+} from 'react-native';
+import { useThemedStyles, Theme } from '../theme';
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+type BodyViewerProps = {
+  content?: string;
+  data?: JsonValue;
+  initiallyExpanded?: boolean;
+};
+
+const BodyViewer: React.FC<BodyViewerProps> = ({
+  content,
+  data,
+  initiallyExpanded = true,
+}) => {
+  const parsed = useMemo(() => {
+    if (data !== undefined) return { isJson: true, value: data } as const;
+    return parseIfJson(content || '');
+  }, [content, data]);
+
+  if (parsed.isJson && parsed.value !== null) {
+    return (
+      <CollapsibleJsonView
+        data={parsed.value}
+        initiallyExpanded={initiallyExpanded}
+      />
+    );
+  }
+
+  return <TextViewer>{content || ''}</TextViewer>;
+};
+
+export default BodyViewer;
+
+const isObject = (v: JsonValue): v is { [key: string]: JsonValue } =>
+  !!v && typeof v === 'object' && !Array.isArray(v);
+
+const isArray = (v: JsonValue): v is JsonValue[] => Array.isArray(v);
+
+const stringifyPrimitive = (value: JsonPrimitive) => {
+  if (typeof value === 'string') return `"${value}"`;
+  if (value === null) return 'null';
+  return String(value);
+};
+
+const ExpandRow: React.FC<{
+  name?: string | number;
+  level: number;
+  open: string;
+  close: string;
+  expanded: boolean;
+  hasChildren: boolean;
+  childrenCount: number;
+  onToggle: () => void;
+  children?: React.ReactNode;
+}> = ({
+  name,
+  level,
+  open,
+  close,
+  expanded,
+  hasChildren,
+  childrenCount,
+  onToggle,
+  children,
+}) => {
+  const styles = useThemedStyles(themedStyles);
+  return (
+    <View
+      style={[
+        styles.jsonLevelContainerBase,
+        level % 2 === 0 ? styles.jsonLevelEven : styles.jsonLevelOdd,
+      ]}
+    >
+      <TouchableOpacity
+        onPress={onToggle}
+        disabled={!hasChildren}
+        accessibilityRole="button"
+        accessibilityLabel="Expand or collapse section"
+        style={[styles.jsonRow, { paddingLeft: level * 12 }]}
+      >
+        <Text style={[styles.baseText, styles.jsonText]}>
+          {hasChildren ? (expanded ? '▼ ' : '▶ ') : ''}
+          {name !== undefined ? `${String(name)}: ` : ''}
+          <Text style={[styles.baseText, styles.jsonBracket]}>{open}</Text>
+          {!expanded ? `${hasChildren ? childrenCount : ''}` : ''}
+          {!expanded ? (
+            <Text style={[styles.baseText, styles.jsonBracket]}>{close}</Text>
+          ) : null}
+        </Text>
+      </TouchableOpacity>
+      {expanded && (
+        <>
+          {children}
+          <Text style={[styles.baseText, styles.jsonText, styles.jsonBracket]}>
+            {close}
+          </Text>
+        </>
+      )}
+    </View>
+  );
+};
+
+const JsonNode: React.FC<{
+  name?: string | number;
+  value: JsonValue;
+  level: number;
+  initiallyExpanded?: boolean;
+}> = ({ name, value, level, initiallyExpanded = false }) => {
+  const styles = useThemedStyles(themedStyles);
+  const [expanded, setExpanded] = useState(initiallyExpanded);
+
+  if (isObject(value)) {
+    const entries = Object.entries(value);
+    const open = '{';
+    const close = '}';
+    const hasLength = entries.length > 0;
+    return (
+      <ExpandRow
+        name={name}
+        level={level}
+        open={open}
+        close={close}
+        expanded={expanded}
+        hasChildren={hasLength}
+        childrenCount={entries.length}
+        onToggle={() => setExpanded((e) => !e)}
+      >
+        {entries.map(([k, v]) => (
+          <JsonNode key={k} name={k} value={v} level={level + 1} />
+        ))}
+      </ExpandRow>
+    );
+  }
+
+  if (isArray(value)) {
+    const open = '[';
+    const close = ']';
+    const hasLength = value?.length > 0;
+    return (
+      <ExpandRow
+        name={name}
+        level={level}
+        open={open}
+        close={close}
+        expanded={expanded}
+        hasChildren={!!hasLength}
+        childrenCount={value?.length || 0}
+        onToggle={() => setExpanded((e) => !e)}
+      >
+        {value.map((v, idx) => (
+          <JsonNode key={idx} name={idx} value={v} level={level + 1} />
+        ))}
+      </ExpandRow>
+    );
+  }
+
+  return (
+    <View style={[styles.jsonRow, { paddingLeft: level * 12 }]}>
+      <Text style={[styles.baseText, styles.jsonText]}>
+        {name !== undefined ? `${String(name)}: ` : ''}
+        {stringifyPrimitive(value as JsonPrimitive)}
+      </Text>
+    </View>
+  );
+};
+
+const CollapsibleJsonView: React.FC<{
+  data: JsonValue;
+  initiallyExpanded?: boolean;
+}> = ({ data, initiallyExpanded = true }) => {
+  const styles = useThemedStyles(themedStyles);
+  return (
+    <View style={[styles.content, styles.textAreaContainer]}>
+      <ScrollView nestedScrollEnabled>
+        <JsonNode
+          level={0}
+          value={data}
+          initiallyExpanded={initiallyExpanded}
+        />
+      </ScrollView>
+    </View>
+  );
+};
+
+const parseIfJson = (
+  text: string
+): { isJson: boolean; value: JsonValue | null } => {
+  try {
+    const obj = JSON.parse(text);
+    return { isJson: true, value: obj };
+  } catch {
+    return { isJson: false, value: null };
+  }
+};
+
+const TextViewer: React.FC<{ children: string }> = ({ children }) => {
+  const styles = useThemedStyles(themedStyles);
+
+  if (Platform.OS === 'ios') {
+    /**
+     * A readonly TextInput is used because large Text blocks sometimes don't render on iOS
+     * See this issue https://github.com/facebook/react-native/issues/19453
+     * Note: Even with the fix mentioned in the comments, text with ~10,000 lines still fails to render
+     */
+    return (
+      <TextInput
+        multiline
+        editable={false}
+        value={children}
+        style={[styles.baseText, styles.content, styles.textAreaContainer]}
+      />
+    );
+  }
+
+  return (
+    <View style={styles.textAreaContainer}>
+      <ScrollView nestedScrollEnabled>
+        <Text style={[styles.baseText, styles.content]} selectable>
+          {children}
+        </Text>
+      </ScrollView>
+    </View>
+  );
+};
+
+const themedStyles = (theme: Theme) =>
+  StyleSheet.create({
+    baseText: {
+      fontFamily: Platform.select({
+        ios: 'Menlo',
+        android: 'monospace',
+      }),
+      color: theme.colors.text,
+    },
+    content: {
+      padding: 10,
+      color: theme.colors.text,
+      backgroundColor: theme.colors.card,
+    },
+    textAreaContainer: {
+      maxHeight: 350,
+    },
+    jsonRow: {
+      paddingVertical: 4,
+    },
+    jsonText: {
+      fontSize: 14,
+    },
+    jsonBracket: {
+      paddingStart: 4,
+      color: theme.colors.text,
+    },
+    jsonLevelContainerBase: {
+      borderRadius: 4,
+      marginVertical: 2,
+      paddingBottom: 2,
+    },
+    jsonLevelEven: {
+      backgroundColor: `${theme.colors.card}ff`,
+    },
+    jsonLevelOdd: {
+      backgroundColor: `${theme.colors.background}44`,
+    },
+  });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,22 +20,26 @@ const Header: React.FC<Props> = ({
 }) => {
   const styles = useThemedStyles(themedStyles);
   const prefix = collapsible ? (expanded ? '▼ ' : '▶ ') : '';
+  const titleContent = (
+    <Text style={styles.header} accessibilityRole="header" testID="header-text">
+      {prefix + children}
+    </Text>
+  );
+
   return (
     <View style={styles.container}>
-      <TouchableOpacity
-        testID="header-toggle"
-        accessibilityRole="button"
-        activeOpacity={collapsible ? 0.6 : 1}
-        onPress={collapsible && onToggle ? onToggle : undefined}
-      >
-        <Text
-          style={styles.header}
-          accessibilityRole="header"
-          testID="header-text"
+      {collapsible ? (
+        <TouchableOpacity
+          testID="header-toggle"
+          accessibilityRole="button"
+          activeOpacity={0.6}
+          onPress={onToggle}
         >
-          {prefix + children}
-        </Text>
-      </TouchableOpacity>
+          {titleContent}
+        </TouchableOpacity>
+      ) : (
+        <View testID="header-toggle">{titleContent}</View>
+      )}
 
       {!!shareContent && (
         <Icon

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,24 +1,41 @@
 import React from 'react';
-import { View, Text, StyleSheet, Share } from 'react-native';
+import { View, Text, StyleSheet, Share, TouchableOpacity } from 'react-native';
 import { useThemedStyles, Theme } from '../theme';
 import Icon from './Icon';
 
 interface Props {
   children: string;
   shareContent?: string;
+  collapsible?: boolean;
+  expanded?: boolean;
+  onToggle?: () => void;
 }
 
-const Header: React.FC<Props> = ({ children, shareContent }) => {
+const Header: React.FC<Props> = ({
+  children,
+  shareContent,
+  collapsible,
+  expanded = false,
+  onToggle,
+}) => {
   const styles = useThemedStyles(themedStyles);
   return (
     <View style={styles.container}>
-      <Text
-        style={styles.header}
-        accessibilityRole="header"
-        testID="header-text"
+      <TouchableOpacity
+        testID="header-toggle"
+        accessibilityRole="button"
+        activeOpacity={collapsible ? 0.6 : 1}
+        onPress={collapsible && onToggle ? onToggle : undefined}
       >
-        {children}
-      </Text>
+        <Text
+          style={styles.header}
+          accessibilityRole="header"
+          testID="header-text"
+        >
+          {collapsible ? (expanded ? '▼ ' : '▶ ') : ''}
+          {children}
+        </Text>
+      </TouchableOpacity>
 
       {!!shareContent && (
         <Icon
@@ -39,7 +56,7 @@ const themedStyles = (theme: Theme) =>
   StyleSheet.create({
     header: {
       fontWeight: 'bold',
-      fontSize: 20,
+      fontSize: 16,
       marginTop: 10,
       marginBottom: 5,
       marginHorizontal: 10,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,6 +19,7 @@ const Header: React.FC<Props> = ({
   onToggle,
 }) => {
   const styles = useThemedStyles(themedStyles);
+  const prefix = collapsible ? (expanded ? '▼ ' : '▶ ') : '';
   return (
     <View style={styles.container}>
       <TouchableOpacity
@@ -32,8 +33,7 @@ const Header: React.FC<Props> = ({
           accessibilityRole="header"
           testID="header-text"
         >
-          {collapsible ? (expanded ? '▼ ' : '▶ ') : ''}
-          {children}
+          {prefix + children}
         </Text>
       </TouchableOpacity>
 

--- a/src/components/NetworkLogger.tsx
+++ b/src/components/NetworkLogger.tsx
@@ -122,6 +122,7 @@ const NetworkLogger: React.FC<Props> = ({
           {showDetails && !!request && (
             <View style={styles.visible}>
               <RequestDetails
+                compact={compact}
                 onClose={() => setShowDetails(false)}
                 request={request}
               />

--- a/src/components/NetworkLogger.tsx
+++ b/src/components/NetworkLogger.tsx
@@ -16,6 +16,10 @@ interface Props {
   sort?: 'asc' | 'desc';
   compact?: boolean;
   maxRows?: number;
+  initialRequestHeadersExpanded?: boolean;
+  initialResponseHeadersExpanded?: boolean;
+  initialRequestBodyExpanded?: boolean;
+  initialResponseBodyExpanded?: boolean;
 }
 
 const sortRequests = (requests: NetworkRequestInfo[], sort: 'asc' | 'desc') => {
@@ -30,6 +34,10 @@ const NetworkLogger: React.FC<Props> = ({
   sort = 'desc',
   compact = false,
   maxRows,
+  initialRequestHeadersExpanded,
+  initialResponseHeadersExpanded,
+  initialRequestBodyExpanded,
+  initialResponseBodyExpanded,
 }) => {
   const [requests, setRequests] = useState(logger.getRequests());
   const [request, setRequest] = useState<NetworkRequestInfo>();
@@ -125,6 +133,10 @@ const NetworkLogger: React.FC<Props> = ({
                 compact={compact}
                 onClose={() => setShowDetails(false)}
                 request={request}
+                initialRequestHeadersExpanded={initialRequestHeadersExpanded}
+                initialResponseHeadersExpanded={initialResponseHeadersExpanded}
+                initialRequestBodyExpanded={initialRequestBodyExpanded}
+                initialResponseBodyExpanded={initialResponseBodyExpanded}
               />
             </View>
           )}

--- a/src/components/RequestDetails.tsx
+++ b/src/components/RequestDetails.tsx
@@ -18,29 +18,44 @@ import Button from './Button';
 interface Props {
   request: NetworkRequestInfo;
   onClose(): void;
+  compact?: boolean;
 }
 
 const Headers = ({
   title = 'Headers',
-  headers,
+  headers = {},
 }: {
   title: string;
   headers?: object;
 }) => {
   const styles = useThemedStyles(themedStyles);
+  const [expanded, setExpanded] = useState(true);
   return (
     <View>
-      <Header shareContent={headers && JSON.stringify(headers, null, 2)}>
+      <Header
+        collapsible
+        expanded={expanded}
+        onToggle={() => setExpanded((e) => !e)}
+        shareContent={headers && JSON.stringify(headers, null, 2)}
+      >
         {title}
       </Header>
-      <View style={styles.content}>
-        {Object.entries(headers || {}).map(([name, value]) => (
-          <View style={styles.headerContainer} key={name}>
-            <Text style={styles.headerKey}>{name}: </Text>
-            <Text style={styles.headerValue}>{value}</Text>
-          </View>
-        ))}
-      </View>
+      {expanded && (
+        <View style={styles.content}>
+          {Object.entries(headers).map(([name, value], index) => (
+            <View
+              key={name}
+              style={[
+                styles.headerContainer,
+                index % 2 !== 0 && styles.headerOddEntries,
+              ]}
+            >
+              <Text style={[styles.baseText, styles.headerKey]}>{name}: </Text>
+              <Text style={[styles.baseText, styles.headerValue]}>{value}</Text>
+            </View>
+          ))}
+        </View>
+      )}
     </View>
   );
 };
@@ -56,7 +71,7 @@ const LargeText: React.FC<{ children: string }> = ({ children }) => {
      */
     return (
       <TextInput
-        style={[styles.content, styles.largeContent]}
+        style={[styles.baseText, styles.content, styles.largeContent]}
         multiline
         editable={false}
         value={children}
@@ -67,19 +82,23 @@ const LargeText: React.FC<{ children: string }> = ({ children }) => {
   return (
     <View style={styles.largeContent}>
       <ScrollView nestedScrollEnabled>
-        <View>
-          <Text style={styles.content} selectable>
-            {children}
-          </Text>
-        </View>
+        <Text style={[styles.baseText, styles.content]} selectable>
+          {children}
+        </Text>
       </ScrollView>
     </View>
   );
 };
 
-const RequestDetails: React.FC<Props> = ({ request, onClose }) => {
+const RequestDetails: React.FC<Props> = ({
+  request,
+  onClose,
+  compact = false,
+}) => {
   const [responseBody, setResponseBody] = useState('Loading...');
   const styles = useThemedStyles(themedStyles);
+  const [requestBodyExpanded, setRequestBodyExpanded] = useState(true);
+  const [responseBodyExpanded, setResponseBodyExpanded] = useState(true);
 
   useEffect(() => {
     (async () => {
@@ -109,27 +128,42 @@ const RequestDetails: React.FC<Props> = ({ request, onClose }) => {
 
   return (
     <View style={styles.container}>
-      <ResultItem request={request} style={styles.info} />
+      <ResultItem request={request} style={styles.info} compact={compact} />
       <ScrollView style={styles.scrollView} nestedScrollEnabled>
         <Headers title="Request Headers" headers={request.requestHeaders} />
-        <Header shareContent={requestBody}>Request Body</Header>
-        <LargeText>{requestBody}</LargeText>
+        <Header
+          collapsible
+          shareContent={requestBody}
+          expanded={requestBodyExpanded}
+          onToggle={() => setRequestBodyExpanded((e) => !e)}
+        >
+          Request Body
+        </Header>
+        {requestBodyExpanded && <LargeText>{requestBody}</LargeText>}
         <Headers title="Response Headers" headers={request.responseHeaders} />
-        <Header shareContent={responseBody}>Response Body</Header>
-        <LargeText>{responseBody}</LargeText>
-        <Header>More</Header>
-        <Button
-          onPress={() => Share.share({ message: getFullRequest() })}
-          fullWidth
+        <Header
+          collapsible
+          shareContent={responseBody}
+          expanded={responseBodyExpanded}
+          onToggle={() => setResponseBodyExpanded((e) => !e)}
         >
-          Share full request
-        </Button>
-        <Button
-          onPress={() => Share.share({ message: request.curlRequest })}
-          fullWidth
-        >
-          Share as cURL
-        </Button>
+          Response Body
+        </Header>
+        {responseBodyExpanded && <LargeText>{responseBody}</LargeText>}
+        <View style={styles.moreButtons}>
+          <Button
+            onPress={() => Share.share({ message: getFullRequest() })}
+            textStyle={styles.buttonText}
+          >
+            Share full request
+          </Button>
+          <Button
+            onPress={() => Share.share({ message: request.curlRequest })}
+            textStyle={styles.buttonText}
+          >
+            Share as cURL
+          </Button>
+        </View>
       </ScrollView>
       {!backHandlerSet() && (
         <Button onPress={onClose} style={styles.close}>
@@ -160,20 +194,44 @@ const themedStyles = (theme: Theme) =>
     scrollView: {
       width: '100%',
     },
-    headerContainer: { flexDirection: 'row', flexWrap: 'wrap' },
-    headerKey: { fontWeight: 'bold', color: theme.colors.text },
-    headerValue: { color: theme.colors.text },
-    text: {
-      fontSize: 16,
+    baseText: {
+      fontFamily: Platform.select({
+        ios: 'Menlo',
+        android: 'monospace',
+      }),
       color: theme.colors.text,
+    },
+    headerContainer: {
+      padding: 4,
+      borderRadius: 4,
+      flexWrap: 'wrap',
+      flexDirection: 'row',
+    },
+    headerOddEntries: {
+      backgroundColor: `${theme.colors.background}33`,
+    },
+    headerKey: {
+      fontSize: 13,
+      fontWeight: 'bold',
+    },
+    headerValue: {
+      fontSize: 12,
     },
     content: {
       backgroundColor: theme.colors.card,
       padding: 10,
-      color: theme.colors.text,
     },
     largeContent: {
-      maxHeight: 300,
+      maxHeight: 350,
+    },
+    moreButtons: {
+      gap: 10,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    buttonText: {
+      fontSize: 16,
     },
   });
 

--- a/src/components/RequestDetails.tsx
+++ b/src/components/RequestDetails.tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   ScrollView,
   Share,
-  TextInput,
   Platform,
 } from 'react-native';
 import NetworkRequestInfo from '../NetworkRequestInfo';
@@ -14,22 +13,29 @@ import { backHandlerSet } from '../backHandler';
 import ResultItem from './ResultItem';
 import Header from './Header';
 import Button from './Button';
+import BodyViewer from './BodyViewer';
 
 interface Props {
   request: NetworkRequestInfo;
   onClose(): void;
   compact?: boolean;
+  initialRequestHeadersExpanded?: boolean;
+  initialResponseHeadersExpanded?: boolean;
+  initialRequestBodyExpanded?: boolean;
+  initialResponseBodyExpanded?: boolean;
 }
 
 const Headers = ({
   title = 'Headers',
   headers = {},
+  initiallyExpanded = true,
 }: {
   title: string;
   headers?: object;
+  initiallyExpanded?: boolean;
 }) => {
   const styles = useThemedStyles(themedStyles);
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useState(initiallyExpanded);
   return (
     <View>
       <Header
@@ -60,45 +66,23 @@ const Headers = ({
   );
 };
 
-const LargeText: React.FC<{ children: string }> = ({ children }) => {
-  const styles = useThemedStyles(themedStyles);
-
-  if (Platform.OS === 'ios') {
-    /**
-     * A readonly TextInput is used because large Text blocks sometimes don't render on iOS
-     * See this issue https://github.com/facebook/react-native/issues/19453
-     * Note: Even with the fix mentioned in the comments, text with ~10,000 lines still fails to render
-     */
-    return (
-      <TextInput
-        style={[styles.baseText, styles.content, styles.largeContent]}
-        multiline
-        editable={false}
-        value={children}
-      />
-    );
-  }
-
-  return (
-    <View style={styles.largeContent}>
-      <ScrollView nestedScrollEnabled>
-        <Text style={[styles.baseText, styles.content]} selectable>
-          {children}
-        </Text>
-      </ScrollView>
-    </View>
-  );
-};
-
 const RequestDetails: React.FC<Props> = ({
   request,
   onClose,
   compact = false,
+  initialRequestHeadersExpanded = true,
+  initialResponseHeadersExpanded = true,
+  initialRequestBodyExpanded = true,
+  initialResponseBodyExpanded = true,
 }) => {
   const [responseBody, setResponseBody] = useState('Loading...');
   const styles = useThemedStyles(themedStyles);
-  const [requestBodyExpanded, setRequestBodyExpanded] = useState(true);
-  const [responseBodyExpanded, setResponseBodyExpanded] = useState(true);
+  const [requestBodyExpanded, setRequestBodyExpanded] = useState(
+    initialRequestBodyExpanded
+  );
+  const [responseBodyExpanded, setResponseBodyExpanded] = useState(
+    initialResponseBodyExpanded
+  );
 
   useEffect(() => {
     (async () => {
@@ -130,7 +114,11 @@ const RequestDetails: React.FC<Props> = ({
     <View style={styles.container}>
       <ResultItem request={request} style={styles.info} compact={compact} />
       <ScrollView style={styles.scrollView} nestedScrollEnabled>
-        <Headers title="Request Headers" headers={request.requestHeaders} />
+        <Headers
+          title="Request Headers"
+          headers={request.requestHeaders}
+          initiallyExpanded={initialRequestHeadersExpanded}
+        />
         <Header
           collapsible
           shareContent={requestBody}
@@ -139,8 +127,17 @@ const RequestDetails: React.FC<Props> = ({
         >
           Request Body
         </Header>
-        {requestBodyExpanded && <LargeText>{requestBody}</LargeText>}
-        <Headers title="Response Headers" headers={request.responseHeaders} />
+        {requestBodyExpanded && (
+          <BodyViewer
+            content={requestBody}
+            initiallyExpanded={initialRequestBodyExpanded}
+          />
+        )}
+        <Headers
+          title="Response Headers"
+          headers={request.responseHeaders}
+          initiallyExpanded={initialResponseHeadersExpanded}
+        />
         <Header
           collapsible
           shareContent={responseBody}
@@ -149,8 +146,13 @@ const RequestDetails: React.FC<Props> = ({
         >
           Response Body
         </Header>
-        {responseBodyExpanded && <LargeText>{responseBody}</LargeText>}
-        <View style={styles.moreButtons}>
+        {responseBodyExpanded && (
+          <BodyViewer
+            content={responseBody}
+            initiallyExpanded={initialResponseBodyExpanded}
+          />
+        )}
+        <View style={styles.moreActionsContainer}>
           <Button
             onPress={() => Share.share({ message: getFullRequest() })}
             textStyle={styles.buttonText}
@@ -221,10 +223,7 @@ const themedStyles = (theme: Theme) =>
       backgroundColor: theme.colors.card,
       padding: 10,
     },
-    largeContent: {
-      maxHeight: 350,
-    },
-    moreButtons: {
+    moreActionsContainer: {
       gap: 10,
       flexDirection: 'row',
       alignItems: 'center',


### PR DESCRIPTION
### Summary
Add a `BodyViewer` component for displaying request/response bodies with JSON tree viewing and text fallback, plus initial expansion controls throughout `RequestDetails`.

### Motivation
- Improve readability of large JSON payloads with a collapsible tree.
- Provide better defaults via initial expansion controls for sections (headers and bodies).

### Changes
- **New component**: `BodyViewer`
  - Detects JSON strings and renders a collapsible tree; falls back to text view.
  - iOS uses read-only `TextInput` for large content rendering reliability.
  - Supports `data` prop to bypass parsing and render prepared JSON.
  - Basic styling and nested scroll support for better UX.
- **RequestDetails enhancements**
  - New props:
    - `initialRequestHeadersExpanded?: boolean` (default: `true`)
    - `initialResponseHeadersExpanded?: boolean` (default: `true`)
    - `initialRequestBodyExpanded?: boolean` (default: `true`)
    - `initialResponseBodyExpanded?: boolean` (default: `true`)
  - Uses `BodyViewer` for request/response bodies with collapsible sections.
  - Adds “Share full request” and “Share as cURL” actions.
- **Header**
  - Indicator `▼/▶` shows only when `collapsible`.

### Usage
```tsx
<RequestDetails
  request={request}
  onClose={close}
  initialRequestHeadersExpanded={true}
  initialResponseHeadersExpanded={false}
  initialRequestBodyExpanded={true}
  initialResponseBodyExpanded={false}
/>
```

If you want to directly render JSON data:
```tsx
<BodyViewer data={{ foo: 'bar', list: [1, 2, 3] }} initiallyExpanded />
```

### UI/UX
- JSON bodies: Collapsible, indented view with alternating backgrounds per level.
- Text bodies: Scrollable view; on iOS uses read-only `TextInput` for large content stability.

### Backward Compatibility
- Defaults keep previous behavior (all sections expanded initially).
- No breaking API changes.

### Testing
- All tests pass.
- Manual checks for:
  - Collapsible behavior for headers and bodies.
  - JSON parse vs. plain text fallback.
  - Share actions.

### Performance
- JSON parsing only when `content` is a string and `data` isn’t provided.
- Tree rendering uses toggling to limit on-screen content.

### Screenshots/GIFs
<p align="center">
  <img src="https://github.com/user-attachments/assets/ddca4dad-2f17-4544-a515-19202b835091" alt="Screenshot 1" width="45%" />
  <img src="https://github.com/user-attachments/assets/790b5ad3-02c3-424e-a9f7-4f320a9e8977" alt="Screenshot 2" width="45%" />
</p>
<p align="center">
  <img src="https://github.com/user-attachments/assets/09ced7e5-62eb-4fa2-94f6-c49fa8b7563f" alt="Screenshot 3" width="45%" />
  <img src="https://github.com/user-attachments/assets/914ca8fd-87e6-4d4f-89db-41682b0fcf90" alt="Screenshot 4" width="45%" />
</p>
