### PR TITLE
Add optional transport for native-logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,25 @@ If you are running another network logging interceptor, e.g. Reactotron, the log
 startNetworkLogging({ forceEnable: true });
 ```
 
+#### Native Transport Plugin (iOS + Android)
+
+By default, requests are captured via JavaScript XHR interception (`transport: "js"`).
+To use native transport, install and register the plugin package:
+
+```bash
+yarn add react-native-network-logger-native
+```
+
+```ts
+import { startNetworkLogging } from 'react-native-network-logger';
+import { registerNativeNetworkLoggerTransport } from 'react-native-network-logger-native';
+
+registerNativeNetworkLoggerTransport();
+startNetworkLogging({ transport: 'native' });
+```
+
+The base package does not include native code, so native pods/gradle setup are only added when you install this plugin package.
+
 #### Integrate with existing navigation
 
 Use your existing back button (e.g. in your navigation header) to navigate within the network logger.
@@ -226,6 +245,23 @@ yarn example start
 ```
 
 You should then be able to open the expo server at http://localhost:3000/ and launch the app on iOS or Android.
+
+### Native Example (Expo prebuild)
+
+For the native transport example, use the separate workspace:
+
+```sh
+yarn example-native native:ios
+```
+
+For Android:
+
+```sh
+yarn example-native native:android
+```
+
+`native:ios` runs Expo prebuild for iOS, installs pods, and launches the native iOS app.  
+`native:android` runs Expo prebuild for Android and launches the native Android app.
 
 For more setup and development details, see [Contributing](#Contributing).
 

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     }
   },
   "workspaces": [
-    "example"
+    "example",
+    "react-native-network-logger-native"
   ],
   "packageManager": "yarn@3.6.1",
   "release-it": {

--- a/react-native-network-logger-native/README.md
+++ b/react-native-network-logger-native/README.md
@@ -1,0 +1,15 @@
+# react-native-network-logger-native
+
+Native transport plugin for `react-native-network-logger`.
+
+## Usage
+
+```ts
+import { startNetworkLogging } from 'react-native-network-logger';
+import { registerNativeNetworkLoggerTransport } from 'react-native-network-logger-native';
+
+registerNativeNetworkLoggerTransport();
+startNetworkLogging({ transport: 'native' });
+```
+
+The plugin registers a `native` transport that captures native networking (iOS `NSURLSession`, Android `OkHttp` used by React Native networking).

--- a/react-native-network-logger-native/android/build.gradle
+++ b/react-native-network-logger-native/android/build.gradle
@@ -1,0 +1,49 @@
+buildscript {
+  repositories {
+    google()
+    mavenCentral()
+  }
+  dependencies {
+    classpath("com.android.tools.build:gradle:8.6.0")
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21")
+  }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
+
+android {
+  namespace "com.rnnetworkloggernative"
+  compileSdkVersion 35
+
+  defaultConfig {
+    minSdkVersion 24
+    targetSdkVersion 35
+  }
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
+  }
+
+  kotlinOptions {
+    jvmTarget = '17'
+  }
+
+  sourceSets {
+    main {
+      manifest.srcFile 'src/main/AndroidManifest.xml'
+    }
+  }
+}
+
+repositories {
+  google()
+  mavenCentral()
+}
+
+dependencies {
+  implementation "com.facebook.react:react-android"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib"
+  implementation "com.squareup.okhttp3:okhttp:4.12.0"
+}

--- a/react-native-network-logger-native/android/src/main/AndroidManifest.xml
+++ b/react-native-network-logger-native/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.rnnetworkloggernative">
+</manifest>

--- a/react-native-network-logger-native/android/src/main/java/com/rnnetworkloggernative/RNNetworkLoggerNativeModule.kt
+++ b/react-native-network-logger-native/android/src/main/java/com/rnnetworkloggernative/RNNetworkLoggerNativeModule.kt
@@ -1,0 +1,216 @@
+package com.rnnetworkloggernative
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.modules.network.CustomClientBuilder
+import com.facebook.react.modules.network.NetworkingModule
+import java.io.IOException
+import java.util.UUID
+import okhttp3.Interceptor
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody
+import okhttp3.Response
+import okio.Buffer
+
+class RNNetworkLoggerNativeModule(
+    private val reactContext: ReactApplicationContext,
+) : ReactContextBaseJavaModule(reactContext) {
+
+  companion object {
+    private const val MODULE_NAME = "RNNetworkLoggerNativeTransport"
+    private const val MAX_BODY_BYTES = 1024L * 64L
+
+    private var isRunning = false
+    private var interceptor: RNNetworkLoggerInterceptor? = null
+
+    private fun toUtf8Body(body: RequestBody?): String {
+      if (body == null) return ""
+      return try {
+        val buffer = Buffer()
+        body.writeTo(buffer)
+        val size = buffer.size
+        if (size > MAX_BODY_BYTES) {
+          val clipped = buffer.readUtf8(MAX_BODY_BYTES)
+          "$clipped... [truncated]"
+        } else {
+          buffer.readUtf8()
+        }
+      } catch (_: Exception) {
+        ""
+      }
+    }
+
+    private fun toUtf8ResponseBody(response: Response): String {
+      val body = response.body ?: return ""
+      return try {
+        val peeked = response.peekBody(MAX_BODY_BYTES)
+        peeked.string()
+      } catch (_: Exception) {
+        ""
+      }
+    }
+
+    private fun contentType(mediaType: MediaType?): String {
+      return mediaType?.toString() ?: ""
+    }
+
+    private fun responseHeaders(response: Response): WritableMap {
+      val map = Arguments.createMap()
+      for ((name, value) in response.headers) {
+        map.putString(name, value)
+      }
+      return map
+    }
+
+    private fun requestHeaders(chainRequest: okhttp3.Request, requestId: String) {
+      val headers = chainRequest.headers
+      for (index in 0 until headers.size) {
+        val headerName = headers.name(index)
+        val headerValue = headers.value(index)
+        emit(
+            "networkLoggerRequestHeader",
+            Arguments.createMap().apply {
+              putString("id", requestId)
+              putString("header", headerName)
+              putString("value", headerValue)
+            },
+        )
+      }
+    }
+
+    private fun emit(event: String, payload: WritableMap) {
+      val emitter = currentEmitter ?: return
+      if (!emitter.reactApplicationContext.hasActiveCatalystInstance()) return
+      emitter.reactApplicationContext
+          .getJSModule(com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+          .emit(event, payload)
+    }
+
+    private var currentEmitter: RNNetworkLoggerNativeModule? = null
+  }
+
+  private class RNNetworkLoggerInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+      val request = chain.request()
+      val requestId = UUID.randomUUID().toString()
+
+      emit(
+          "networkLoggerRequestOpen",
+          Arguments.createMap().apply {
+            putString("id", requestId)
+            putString("method", request.method)
+            putString("url", request.url.toString())
+          },
+      )
+
+      requestHeaders(request, requestId)
+
+      emit(
+          "networkLoggerRequestSend",
+          Arguments.createMap().apply {
+            putString("id", requestId)
+            putString("body", toUtf8Body(request.body))
+          },
+      )
+
+      return try {
+        val response = chain.proceed(request)
+
+        emit(
+            "networkLoggerResponseHeaders",
+            Arguments.createMap().apply {
+              putString("id", requestId)
+              putString("contentType", contentType(response.body?.contentType()))
+              putDouble("responseSize", response.body?.contentLength()?.coerceAtLeast(0)?.toDouble() ?: 0.0)
+              putMap("responseHeaders", responseHeaders(response))
+            },
+        )
+
+        emit(
+            "networkLoggerResponse",
+            Arguments.createMap().apply {
+              putString("id", requestId)
+              putInt("status", response.code)
+              putInt("timeout", 0)
+              putString("response", toUtf8ResponseBody(response))
+              putString("responseURL", response.request.url.toString())
+              putString("responseType", "text")
+            },
+        )
+
+        response
+      } catch (error: IOException) {
+        emit(
+            "networkLoggerResponse",
+            Arguments.createMap().apply {
+              putString("id", requestId)
+              putInt("status", 0)
+              putInt("timeout", 0)
+              putString("response", error.message ?: "")
+              putString("responseURL", request.url.toString())
+              putString("responseType", "text")
+            },
+        )
+        throw error
+      }
+    }
+  }
+
+  override fun getName(): String {
+    return MODULE_NAME
+  }
+
+  override fun initialize() {
+    super.initialize()
+    currentEmitter = this
+  }
+
+  override fun invalidate() {
+    if (currentEmitter === this) {
+      currentEmitter = null
+    }
+    super.invalidate()
+  }
+
+  @ReactMethod
+  fun start() {
+    if (isRunning) return
+
+    interceptor = RNNetworkLoggerInterceptor()
+    NetworkingModule.setCustomClientBuilder(
+        CustomClientBuilder { builder: OkHttpClient.Builder ->
+          interceptor?.let { builder.addNetworkInterceptor(it) }
+        },
+    )
+    isRunning = true
+  }
+
+  @ReactMethod
+  fun stop() {
+    if (!isRunning) return
+    NetworkingModule.setCustomClientBuilder(null)
+    interceptor = null
+    isRunning = false
+  }
+
+  @ReactMethod
+  fun makeNativeTestRequest(url: String) {
+    val client = OkHttpClient()
+    val request = okhttp3.Request.Builder().url(url).build()
+    client.newCall(request).enqueue(
+        object : okhttp3.Callback {
+          override fun onFailure(call: okhttp3.Call, e: IOException) {
+            // no-op; this endpoint is only for validating interception.
+          }
+
+          override fun onResponse(call: okhttp3.Call, response: Response) {
+            response.close()
+          }
+        },
+    )
+  }
+}

--- a/react-native-network-logger-native/android/src/main/java/com/rnnetworkloggernative/RNNetworkLoggerNativePackage.kt
+++ b/react-native-network-logger-native/android/src/main/java/com/rnnetworkloggernative/RNNetworkLoggerNativePackage.kt
@@ -1,0 +1,18 @@
+package com.rnnetworkloggernative
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class RNNetworkLoggerNativePackage : ReactPackage {
+  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+    return listOf(RNNetworkLoggerNativeModule(reactContext))
+  }
+
+  override fun createViewManagers(
+      reactContext: ReactApplicationContext,
+  ): List<ViewManager<*, *>> {
+    return emptyList()
+  }
+}

--- a/react-native-network-logger-native/ios/RNNetworkLoggerNativeTransport.h
+++ b/react-native-network-logger-native/ios/RNNetworkLoggerNativeTransport.h
@@ -1,0 +1,10 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNNetworkLoggerNativeTransport : RCTEventEmitter <RCTBridgeModule>
++ (void)emitEvent:(NSString *)name body:(NSDictionary *)body;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/react-native-network-logger-native/ios/RNNetworkLoggerNativeTransport.m
+++ b/react-native-network-logger-native/ios/RNNetworkLoggerNativeTransport.m
@@ -1,0 +1,86 @@
+#import "RNNetworkLoggerNativeTransport.h"
+#import "RNNetworkLoggerURLProtocol.h"
+
+static __weak RNNetworkLoggerNativeTransport *sharedEmitter = nil;
+static BOOL isRunning = NO;
+
+@implementation RNNetworkLoggerNativeTransport
+
+RCT_EXPORT_MODULE()
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[
+    @"networkLoggerRequestOpen",
+    @"networkLoggerRequestHeader",
+    @"networkLoggerRequestSend",
+    @"networkLoggerResponseHeaders",
+    @"networkLoggerResponse"
+  ];
+}
+
+- (void)startObserving
+{
+  sharedEmitter = self;
+}
+
+- (void)stopObserving
+{
+  if (sharedEmitter == self) {
+    sharedEmitter = nil;
+  }
+}
+
++ (void)emitEvent:(NSString *)name body:(NSDictionary *)body
+{
+  if (sharedEmitter == nil) {
+    return;
+  }
+  [sharedEmitter sendEventWithName:name body:body];
+}
+
+RCT_EXPORT_METHOD(start)
+{
+  if (isRunning) {
+    return;
+  }
+  [RNNetworkLoggerURLProtocol installInterception];
+  [NSURLProtocol registerClass:[RNNetworkLoggerURLProtocol class]];
+  isRunning = YES;
+}
+
+RCT_EXPORT_METHOD(stop)
+{
+  if (!isRunning) {
+    return;
+  }
+  [NSURLProtocol unregisterClass:[RNNetworkLoggerURLProtocol class]];
+  [RNNetworkLoggerURLProtocol uninstallInterception];
+  isRunning = NO;
+}
+
+RCT_EXPORT_METHOD(makeNativeTestRequest:(NSString *)urlString)
+{
+  if (urlString == nil || urlString.length == 0) {
+    return;
+  }
+
+  NSURL *url = [NSURL URLWithString:urlString];
+  if (url == nil) {
+    return;
+  }
+
+  NSURLSessionDataTask *task =
+      [[NSURLSession sharedSession] dataTaskWithURL:url
+                                  completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                                    // no-op: this endpoint is just used to validate interception.
+                                  }];
+  [task resume];
+}
+
+@end

--- a/react-native-network-logger-native/ios/RNNetworkLoggerURLProtocol.h
+++ b/react-native-network-logger-native/ios/RNNetworkLoggerURLProtocol.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNNetworkLoggerURLProtocol : NSURLProtocol
++ (void)installInterception;
++ (void)uninstallInterception;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/react-native-network-logger-native/ios/RNNetworkLoggerURLProtocol.m
+++ b/react-native-network-logger-native/ios/RNNetworkLoggerURLProtocol.m
@@ -1,0 +1,237 @@
+#import "RNNetworkLoggerURLProtocol.h"
+#import "RNNetworkLoggerNativeTransport.h"
+#import <objc/runtime.h>
+
+static NSString *const kHandledKey = @"RNNetworkLoggerHandled";
+
+typedef NSURLSessionConfiguration *(*SessionConfigGetter)(id, SEL);
+
+static BOOL isSwizzled = NO;
+static IMP originalDefaultIMP = NULL;
+static IMP originalEphemeralIMP = NULL;
+
+static NSURLSessionConfiguration *rnlogger_swizzledDefault(id self, SEL _cmd)
+{
+  NSURLSessionConfiguration *config = nil;
+  if (originalDefaultIMP != NULL) {
+    config = ((SessionConfigGetter)originalDefaultIMP)(self, _cmd);
+  }
+  if (config == nil) {
+    config = [NSURLSessionConfiguration defaultSessionConfiguration];
+  }
+
+  NSMutableArray *protocols = [config.protocolClasses mutableCopy] ?: [NSMutableArray array];
+  if (![protocols containsObject:[RNNetworkLoggerURLProtocol class]]) {
+    [protocols insertObject:[RNNetworkLoggerURLProtocol class] atIndex:0];
+    config.protocolClasses = protocols;
+  }
+  return config;
+}
+
+static NSURLSessionConfiguration *rnlogger_swizzledEphemeral(id self, SEL _cmd)
+{
+  NSURLSessionConfiguration *config = nil;
+  if (originalEphemeralIMP != NULL) {
+    config = ((SessionConfigGetter)originalEphemeralIMP)(self, _cmd);
+  }
+  if (config == nil) {
+    config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+  }
+
+  NSMutableArray *protocols = [config.protocolClasses mutableCopy] ?: [NSMutableArray array];
+  if (![protocols containsObject:[RNNetworkLoggerURLProtocol class]]) {
+    [protocols insertObject:[RNNetworkLoggerURLProtocol class] atIndex:0];
+    config.protocolClasses = protocols;
+  }
+  return config;
+}
+
+@interface RNNetworkLoggerURLProtocol () <NSURLSessionDataDelegate>
+@property(nonatomic, strong) NSURLSessionDataTask *task;
+@property(nonatomic, strong) NSMutableData *responseData;
+@property(nonatomic, strong) NSString *requestId;
+@property(nonatomic, strong) NSURLResponse *capturedResponse;
+@end
+
+@implementation RNNetworkLoggerURLProtocol
+
++ (void)installInterception
+{
+  if (isSwizzled) {
+    return;
+  }
+
+  Class configClass = [NSURLSessionConfiguration class];
+
+  Method defaultMethod = class_getClassMethod(configClass, @selector(defaultSessionConfiguration));
+  Method ephemeralMethod = class_getClassMethod(configClass, @selector(ephemeralSessionConfiguration));
+
+  if (defaultMethod != NULL) {
+    originalDefaultIMP = method_getImplementation(defaultMethod);
+    method_setImplementation(defaultMethod, (IMP)rnlogger_swizzledDefault);
+  }
+
+  if (ephemeralMethod != NULL) {
+    originalEphemeralIMP = method_getImplementation(ephemeralMethod);
+    method_setImplementation(ephemeralMethod, (IMP)rnlogger_swizzledEphemeral);
+  }
+
+  isSwizzled = YES;
+}
+
++ (void)uninstallInterception
+{
+  if (!isSwizzled) {
+    return;
+  }
+
+  Class configClass = [NSURLSessionConfiguration class];
+
+  if (originalDefaultIMP != NULL) {
+    Method defaultMethod = class_getClassMethod(configClass, @selector(defaultSessionConfiguration));
+    if (defaultMethod != NULL) {
+      method_setImplementation(defaultMethod, originalDefaultIMP);
+    }
+    originalDefaultIMP = NULL;
+  }
+
+  if (originalEphemeralIMP != NULL) {
+    Method ephemeralMethod = class_getClassMethod(configClass, @selector(ephemeralSessionConfiguration));
+    if (ephemeralMethod != NULL) {
+      method_setImplementation(ephemeralMethod, originalEphemeralIMP);
+    }
+    originalEphemeralIMP = NULL;
+  }
+
+  isSwizzled = NO;
+}
+
++ (BOOL)canInitWithRequest:(NSURLRequest *)request
+{
+  if ([NSURLProtocol propertyForKey:kHandledKey inRequest:request]) {
+    return NO;
+  }
+
+  NSString *scheme = request.URL.scheme.lowercaseString;
+  return [scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"];
+}
+
++ (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request
+{
+  return request;
+}
+
+- (void)startLoading
+{
+  self.requestId = NSUUID.UUID.UUIDString;
+  self.responseData = [NSMutableData data];
+
+  NSMutableURLRequest *mutableRequest = [self.request mutableCopy];
+  [NSURLProtocol setProperty:@YES forKey:kHandledKey inRequest:mutableRequest];
+
+  [RNNetworkLoggerNativeTransport emitEvent:@"networkLoggerRequestOpen"
+                                       body:@{
+                                         @"id" : self.requestId ?: @"",
+                                         @"method" : self.request.HTTPMethod ?: @"GET",
+                                         @"url" : self.request.URL.absoluteString ?: @""
+                                       }];
+
+  NSDictionary<NSString *, NSString *> *headers = self.request.allHTTPHeaderFields;
+  [headers enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *obj, BOOL *stop) {
+    [RNNetworkLoggerNativeTransport emitEvent:@"networkLoggerRequestHeader"
+                                         body:@{
+                                           @"id" : self.requestId ?: @"",
+                                           @"header" : key ?: @"",
+                                           @"value" : obj ?: @""
+                                         }];
+  }];
+
+  NSString *requestBody = @"";
+  if (self.request.HTTPBody != nil) {
+    requestBody = [[NSString alloc] initWithData:self.request.HTTPBody encoding:NSUTF8StringEncoding] ?: @"";
+  }
+  [RNNetworkLoggerNativeTransport emitEvent:@"networkLoggerRequestSend"
+                                       body:@{ @"id" : self.requestId ?: @"", @"body" : requestBody }];
+
+  NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+  config.protocolClasses = @[];
+
+  NSURLSession *session = [NSURLSession sessionWithConfiguration:config
+                                                        delegate:self
+                                                   delegateQueue:nil];
+  self.task = [session dataTaskWithRequest:mutableRequest];
+  [self.task resume];
+}
+
+- (void)stopLoading
+{
+  [self.task cancel];
+  self.task = nil;
+}
+
+- (void)URLSession:(NSURLSession *)session
+          dataTask:(NSURLSessionDataTask *)dataTask
+didReceiveResponse:(NSURLResponse *)response
+ completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))completionHandler
+{
+  self.capturedResponse = response;
+
+  NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+  NSDictionary *allHeaders = httpResponse.allHeaderFields ?: @{};
+  NSMutableDictionary<NSString *, NSString *> *responseHeaders = [NSMutableDictionary dictionary];
+  [allHeaders enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+    responseHeaders[[key description]] = [obj description];
+  }];
+
+  [RNNetworkLoggerNativeTransport emitEvent:@"networkLoggerResponseHeaders"
+                                       body:@{
+                                         @"id" : self.requestId ?: @"",
+                                         @"contentType" : response.MIMEType ?: @"",
+                                         @"responseSize" : @(MAX(response.expectedContentLength, 0)),
+                                         @"responseHeaders" : responseHeaders
+                                       }];
+
+  [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageNotAllowed];
+  completionHandler(NSURLSessionResponseAllow);
+}
+
+- (void)URLSession:(NSURLSession *)session
+          dataTask:(NSURLSessionDataTask *)dataTask
+    didReceiveData:(NSData *)data
+{
+  if (data != nil) {
+    [self.responseData appendData:data];
+    [self.client URLProtocol:self didLoadData:data];
+  }
+}
+
+- (void)URLSession:(NSURLSession *)session
+              task:(NSURLSessionTask *)task
+didCompleteWithError:(NSError *)error
+{
+  NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)self.capturedResponse;
+  NSInteger statusCode = httpResponse != nil ? httpResponse.statusCode : 0;
+
+  NSString *responseText = @"";
+  if (self.responseData.length > 0) {
+    responseText = [[NSString alloc] initWithData:self.responseData encoding:NSUTF8StringEncoding] ?: @"";
+  }
+
+  [RNNetworkLoggerNativeTransport emitEvent:@"networkLoggerResponse"
+                                       body:@{
+                                         @"id" : self.requestId ?: @"",
+                                         @"status" : @(statusCode),
+                                         @"timeout" : @(0),
+                                         @"response" : responseText ?: @"",
+                                         @"responseURL" : self.request.URL.absoluteString ?: @"",
+                                         @"responseType" : @"text"
+                                       }];
+
+  if (error != nil) {
+    [self.client URLProtocol:self didFailWithError:error];
+  } else {
+    [self.client URLProtocolDidFinishLoading:self];
+  }
+}
+
+@end

--- a/react-native-network-logger-native/package.json
+++ b/react-native-network-logger-native/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "react-native-network-logger-native",
+  "version": "0.1.0",
+  "description": "Native transport plugin for react-native-network-logger",
+  "main": "./lib/module/index.js",
+  "types": "./lib/typescript/src/index.d.ts",
+  "source": "src/index.ts",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./lib/typescript/src/index.d.ts",
+      "default": "./lib/module/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "lib",
+    "src",
+    "android",
+    "ios",
+    "react-native-network-logger-native.podspec",
+    "!**/__tests__",
+    "!**/*.spec.ts",
+    "!**/*.spec.tsx",
+    "!**/__fixtures__",
+    "!**/__mocks__"
+  ],
+  "scripts": {
+    "prepare": "bob build"
+  },
+  "keywords": [
+    "react-native",
+    "network",
+    "logger",
+    "native",
+    "ios",
+    "android"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alexbrazier/react-native-network-logger.git"
+  },
+  "author": "alexbrazier",
+  "license": "MIT",
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*",
+    "react-native-network-logger": "*"
+  },
+  "devDependencies": {
+    "react-native-builder-bob": "^0.40.18"
+  },
+  "react-native": "src/index.ts",
+  "homepage": "https://github.com/alexbrazier/react-native-network-logger",
+  "react-native-builder-bob": {
+    "source": "src",
+    "output": "lib",
+    "targets": [
+      [
+        "module",
+        {
+          "esm": true
+        }
+      ],
+      [
+        "typescript",
+        {
+          "project": "tsconfig.build.json"
+        }
+      ]
+    ]
+  }
+}

--- a/react-native-network-logger-native/react-native-network-logger-native.podspec
+++ b/react-native-network-logger-native/react-native-network-logger-native.podspec
@@ -1,0 +1,18 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = 'react-native-network-logger-native'
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+  s.homepage     = package['homepage']
+  s.author       = package['author']
+  s.platforms    = { :ios => '13.4' }
+  s.source       = { :git => package['repository']['url'], :tag => "v#{s.version}" }
+  s.source_files = 'ios/**/*.{h,m,mm}'
+  s.requires_arc = true
+
+  s.dependency 'React-Core'
+end

--- a/react-native-network-logger-native/react-native.config.js
+++ b/react-native-network-logger-native/react-native.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        packageImportPath: 'import com.rnnetworkloggernative.RNNetworkLoggerNativePackage;',
+        packageInstance: 'new RNNetworkLoggerNativePackage()',
+      },
+    },
+  },
+};

--- a/react-native-network-logger-native/react-native.config.js
+++ b/react-native-network-logger-native/react-native.config.js
@@ -2,7 +2,8 @@ module.exports = {
   dependency: {
     platforms: {
       android: {
-        packageImportPath: 'import com.rnnetworkloggernative.RNNetworkLoggerNativePackage;',
+        packageImportPath:
+          'import com.rnnetworkloggernative.RNNetworkLoggerNativePackage;',
         packageInstance: 'new RNNetworkLoggerNativePackage()',
       },
     },

--- a/react-native-network-logger-native/src/NativeTransport.ts
+++ b/react-native-network-logger-native/src/NativeTransport.ts
@@ -1,0 +1,197 @@
+import {
+  EmitterSubscription,
+  NativeEventEmitter,
+  NativeModules,
+  Platform,
+} from 'react-native';
+import type { NetworkTransportAdapter } from 'react-native-network-logger';
+
+type OpenCallback = (...args: any[]) => void;
+type RequestHeaderCallback = (...args: any[]) => void;
+type SendCallback = (...args: any[]) => void;
+type HeaderReceivedCallback = (...args: any[]) => void;
+type ResponseCallback = (...args: any[]) => void;
+
+type NativeRequestOpenEvent = {
+  id: string;
+  method: string;
+  url: string;
+};
+
+type NativeRequestHeaderEvent = {
+  id: string;
+  header: string;
+  value: string;
+};
+
+type NativeRequestSendEvent = {
+  id: string;
+  body?: string;
+};
+
+type NativeResponseHeadersEvent = {
+  id: string;
+  contentType?: string;
+  responseSize?: number;
+  responseHeaders?: Record<string, string>;
+};
+
+type NativeResponseEvent = {
+  id: string;
+  status?: number;
+  timeout?: number;
+  response?: string;
+  responseURL?: string;
+  responseType?: string;
+};
+
+type NativeNetworkModule = {
+  start?: () => void;
+  stop?: () => void;
+  makeNativeTestRequest?: (url: string) => void;
+};
+
+const moduleName = 'RNNetworkLoggerNativeTransport';
+const nativeModule = NativeModules[moduleName] as NativeNetworkModule | undefined;
+
+let openCallback: OpenCallback = () => {};
+let requestHeaderCallback: RequestHeaderCallback = () => {};
+let sendCallback: SendCallback = () => {};
+let headerReceivedCallback: HeaderReceivedCallback = () => {};
+let responseCallback: ResponseCallback = () => {};
+
+let isEnabled = false;
+let sequence = 0;
+const xhrByRequestId = new Map<
+  string,
+  {
+    _index: number;
+    responseHeaders?: Record<string, string>;
+  }
+>();
+let subscriptions: EmitterSubscription[] = [];
+
+const getXHR = (requestId: string) => {
+  let xhr = xhrByRequestId.get(requestId);
+  if (!xhr) {
+    xhr = { _index: sequence++ };
+    xhrByRequestId.set(requestId, xhr);
+  }
+  return xhr;
+};
+
+const addSubscriptions = () => {
+  if (!nativeModule) return;
+
+  const emitter = new NativeEventEmitter(nativeModule as any);
+  subscriptions = [
+    emitter.addListener(
+      'networkLoggerRequestOpen',
+      ({ id, method, url }: NativeRequestOpenEvent) => {
+        const xhr = getXHR(id);
+        openCallback(method, url, xhr);
+      }
+    ),
+    emitter.addListener(
+      'networkLoggerRequestHeader',
+      ({ id, header, value }: NativeRequestHeaderEvent) => {
+        const xhr = getXHR(id);
+        requestHeaderCallback(header, value, xhr);
+      }
+    ),
+    emitter.addListener('networkLoggerRequestSend', ({ id, body }: NativeRequestSendEvent) => {
+      const xhr = getXHR(id);
+      sendCallback(body || '', xhr);
+    }),
+    emitter.addListener(
+      'networkLoggerResponseHeaders',
+      ({
+        id,
+        contentType = '',
+        responseSize = 0,
+        responseHeaders = {},
+      }: NativeResponseHeadersEvent) => {
+        const xhr = getXHR(id);
+        xhr.responseHeaders = responseHeaders;
+        headerReceivedCallback(contentType, responseSize, responseHeaders, xhr);
+      }
+    ),
+    emitter.addListener(
+      'networkLoggerResponse',
+      ({
+        id,
+        status = 0,
+        timeout = 0,
+        response = '',
+        responseURL = '',
+        responseType = '',
+      }: NativeResponseEvent) => {
+        const xhr = getXHR(id);
+        responseCallback(
+          status,
+          timeout,
+          response,
+          responseURL,
+          responseType,
+          xhr
+        );
+        xhrByRequestId.delete(id);
+      }
+    ),
+  ];
+};
+
+const removeSubscriptions = () => {
+  subscriptions.forEach((subscription) => subscription.remove());
+  subscriptions = [];
+};
+
+export const nativeNetworkLoggerTransport: NetworkTransportAdapter = {
+  isInterceptorEnabled: () => isEnabled,
+  setOpenCallback: (callback: OpenCallback) => {
+    openCallback = callback;
+  },
+  setRequestHeaderCallback: (callback: RequestHeaderCallback) => {
+    requestHeaderCallback = callback;
+  },
+  setSendCallback: (callback: SendCallback) => {
+    sendCallback = callback;
+  },
+  setHeaderReceivedCallback: (callback: HeaderReceivedCallback) => {
+    headerReceivedCallback = callback;
+  },
+  setResponseCallback: (callback: ResponseCallback) => {
+    responseCallback = callback;
+  },
+  enableInterception: () => {
+    if (isEnabled) return;
+    if (!nativeModule?.start) return;
+    addSubscriptions();
+    nativeModule.start();
+    isEnabled = true;
+  },
+  disableInterception: () => {
+    if (!isEnabled) return;
+    removeSubscriptions();
+    xhrByRequestId.clear();
+    sequence = 0;
+    openCallback = () => {};
+    requestHeaderCallback = () => {};
+    sendCallback = () => {};
+    headerReceivedCallback = () => {};
+    responseCallback = () => {};
+    nativeModule?.stop?.();
+    isEnabled = false;
+  },
+};
+
+export const isNativeTransportSupported = () => {
+  if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
+    return false;
+  }
+  return !!nativeModule?.start;
+};
+
+export const makeNativeTestRequest = (url: string) => {
+  nativeModule?.makeNativeTestRequest?.(url);
+};

--- a/react-native-network-logger-native/src/NativeTransport.ts
+++ b/react-native-network-logger-native/src/NativeTransport.ts
@@ -52,7 +52,9 @@ type NativeNetworkModule = {
 };
 
 const moduleName = 'RNNetworkLoggerNativeTransport';
-const nativeModule = NativeModules[moduleName] as NativeNetworkModule | undefined;
+const nativeModule = NativeModules[moduleName] as
+  | NativeNetworkModule
+  | undefined;
 
 let openCallback: OpenCallback = () => {};
 let requestHeaderCallback: RequestHeaderCallback = () => {};
@@ -99,10 +101,13 @@ const addSubscriptions = () => {
         requestHeaderCallback(header, value, xhr);
       }
     ),
-    emitter.addListener('networkLoggerRequestSend', ({ id, body }: NativeRequestSendEvent) => {
-      const xhr = getXHR(id);
-      sendCallback(body || '', xhr);
-    }),
+    emitter.addListener(
+      'networkLoggerRequestSend',
+      ({ id, body }: NativeRequestSendEvent) => {
+        const xhr = getXHR(id);
+        sendCallback(body || '', xhr);
+      }
+    ),
     emitter.addListener(
       'networkLoggerResponseHeaders',
       ({

--- a/react-native-network-logger-native/src/index.ts
+++ b/react-native-network-logger-native/src/index.ts
@@ -1,0 +1,33 @@
+import {
+  registerNetworkTransport,
+  unregisterNetworkTransport,
+} from 'react-native-network-logger';
+import {
+  isNativeTransportSupported,
+  makeNativeTestRequest,
+  nativeNetworkLoggerTransport,
+} from './NativeTransport';
+
+export const NATIVE_TRANSPORT_NAME = 'native';
+
+export const registerNativeNetworkLoggerTransport = (
+  name: string = NATIVE_TRANSPORT_NAME
+) => {
+  if (!isNativeTransportSupported()) {
+    return false;
+  }
+  registerNetworkTransport(name, nativeNetworkLoggerTransport);
+  return true;
+};
+
+export const unregisterNativeNetworkLoggerTransport = (
+  name: string = NATIVE_TRANSPORT_NAME
+) => {
+  unregisterNetworkTransport(name);
+};
+
+export {
+  isNativeTransportSupported,
+  makeNativeTestRequest,
+  nativeNetworkLoggerTransport,
+};

--- a/react-native-network-logger-native/tsconfig.build.json
+++ b/react-native-network-logger-native/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["lib", "example", "node_modules"]
+}

--- a/react-native-network-logger-native/tsconfig.json
+++ b/react-native-network-logger-native/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {
+      "react-native-network-logger": ["../src/index"]
+    }
+  },
+  "include": ["src"]
+}

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -1,6 +1,10 @@
 import XHRInterceptor from './XHRInterceptor';
 import NetworkRequestInfo from './NetworkRequestInfo';
 import { Headers, RequestMethod, StartNetworkLoggingOptions } from './types';
+import {
+  getNetworkTransport,
+  type NetworkTransportAdapter,
+} from './transportRegistry';
 import extractHost from './utils/extractHost';
 import { warn } from './utils/logger';
 import debounce from './utils/debounce';
@@ -24,6 +28,7 @@ export default class Logger {
   private ignoredUrls: Set<string> | undefined;
   private ignoredPatterns: RegExp[] | undefined;
   private paused = false;
+  private interceptor: NetworkTransportAdapter = XHRInterceptor;
   public enabled = false;
 
   callback = (_: NetworkRequestInfo[]) => null;
@@ -161,9 +166,21 @@ export default class Logger {
   };
 
   enableXHRInterception = (options?: StartNetworkLoggingOptions) => {
+    let interceptor: NetworkTransportAdapter = XHRInterceptor;
+    if (options?.transport && options.transport !== 'js') {
+      const registered = getNetworkTransport(options.transport);
+      if (!registered) {
+        warn(
+          `${options.transport} transport is unavailable (not registered). Network logging has not been started.`
+        );
+        return;
+      }
+      interceptor = registered;
+    }
+
     if (
       this.enabled ||
-      (XHRInterceptor.isInterceptorEnabled() && !options?.forceEnable)
+      (interceptor.isInterceptorEnabled() && !options?.forceEnable)
     ) {
       if (!this.enabled) {
         warn(
@@ -223,13 +240,13 @@ export default class Logger {
       this.ignoredUrls = new Set(options.ignoredUrls);
     }
 
-    XHRInterceptor.setOpenCallback(this.openCallback);
-    XHRInterceptor.setRequestHeaderCallback(this.requestHeadersCallback);
-    XHRInterceptor.setHeaderReceivedCallback(this.headerReceivedCallback);
-    XHRInterceptor.setSendCallback(this.sendCallback);
-    XHRInterceptor.setResponseCallback(this.responseCallback);
-
-    XHRInterceptor.enableInterception();
+    interceptor.setOpenCallback(this.openCallback);
+    interceptor.setRequestHeaderCallback(this.requestHeadersCallback);
+    interceptor.setHeaderReceivedCallback(this.headerReceivedCallback);
+    interceptor.setSendCallback(this.sendCallback);
+    interceptor.setResponseCallback(this.responseCallback);
+    interceptor.enableInterception();
+    this.interceptor = interceptor;
     this.enabled = true;
   };
 
@@ -275,12 +292,12 @@ export default class Logger {
 
     const noop = () => null;
     // manually reset callbacks even if the XHRInterceptor lib does it for us with 'disableInterception'
-    XHRInterceptor.setOpenCallback(noop);
-    XHRInterceptor.setRequestHeaderCallback(noop);
-    XHRInterceptor.setHeaderReceivedCallback(noop);
-    XHRInterceptor.setSendCallback(noop);
-    XHRInterceptor.setResponseCallback(noop);
-
-    XHRInterceptor.disableInterception();
+    this.interceptor.setOpenCallback(noop);
+    this.interceptor.setRequestHeaderCallback(noop);
+    this.interceptor.setHeaderReceivedCallback(noop);
+    this.interceptor.setSendCallback(noop);
+    this.interceptor.setResponseCallback(noop);
+    this.interceptor.disableInterception();
+    this.interceptor = XHRInterceptor;
   };
 }

--- a/src/__tests__/Logger.spec.ts
+++ b/src/__tests__/Logger.spec.ts
@@ -1,4 +1,5 @@
 import XHRInterceptor from '../XHRInterceptor';
+import * as transportRegistry from '../transportRegistry';
 import { warn } from '../utils/logger';
 import Logger from '../Logger';
 import { LOGGER_MAX_REQUESTS, LOGGER_REFRESH_RATE } from '../constant';
@@ -14,6 +15,11 @@ jest.mock('../XHRInterceptor', () => ({
   enableInterception: jest.fn(),
   disableInterception: jest.fn(),
 }));
+jest.mock('../transportRegistry', () => ({
+  registerNetworkTransport: jest.fn(),
+  unregisterNetworkTransport: jest.fn(),
+  getNetworkTransport: jest.fn(),
+}));
 
 jest.mock('../utils/logger', () => ({
   warn: jest.fn(() => {
@@ -23,6 +29,9 @@ jest.mock('../utils/logger', () => ({
 
 beforeEach(() => {
   jest.clearAllMocks();
+  (transportRegistry.getNetworkTransport as jest.Mock).mockReturnValue(
+    undefined
+  );
 });
 
 describe('enableXHRInterception', () => {
@@ -154,6 +163,44 @@ describe('enableXHRInterception', () => {
 
     expect(XHRInterceptor.enableInterception).toHaveBeenCalledTimes(1);
     expect(XHRInterceptor.enableInterception).toHaveBeenCalledWith();
+  });
+
+  it('should use a registered transport when requested', () => {
+    const customTransport = {
+      isInterceptorEnabled: jest.fn().mockReturnValue(false),
+      setOpenCallback: jest.fn(),
+      setRequestHeaderCallback: jest.fn(),
+      setSendCallback: jest.fn(),
+      setHeaderReceivedCallback: jest.fn(),
+      setResponseCallback: jest.fn(),
+      enableInterception: jest.fn(),
+      disableInterception: jest.fn(),
+    };
+    (transportRegistry.getNetworkTransport as jest.Mock).mockReturnValueOnce(
+      customTransport
+    );
+
+    const logger = new Logger();
+    logger.enableXHRInterception({ transport: 'native' });
+
+    expect(customTransport.setOpenCallback).toHaveBeenCalledTimes(1);
+    expect(customTransport.setRequestHeaderCallback).toHaveBeenCalledTimes(1);
+    expect(customTransport.setHeaderReceivedCallback).toHaveBeenCalledTimes(1);
+    expect(customTransport.setSendCallback).toHaveBeenCalledTimes(1);
+    expect(customTransport.setResponseCallback).toHaveBeenCalledTimes(1);
+    expect(customTransport.enableInterception).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.enableInterception).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not start if requested transport is unavailable', () => {
+    (warn as jest.Mock).mockImplementationOnce(() => null);
+    const logger = new Logger();
+
+    logger.enableXHRInterception({ transport: 'native' });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.enableInterception).toHaveBeenCalledTimes(0);
+    expect(logger.enabled).toBe(false);
   });
 });
 

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1,4 +1,5 @@
 import XHRInterceptor from '../XHRInterceptor';
+import * as transportRegistry from '../transportRegistry';
 import { startNetworkLogging, stopNetworkLogging } from '..';
 import logger from '../loggerSingleton';
 import { LOGGER_MAX_REQUESTS, LOGGER_REFRESH_RATE } from '../constant';
@@ -14,12 +15,30 @@ jest.mock('../XHRInterceptor', () => ({
   enableInterception: jest.fn(),
   disableInterception: jest.fn(),
 }));
+jest.mock('../transportRegistry', () => ({
+  registerNetworkTransport: jest.fn(),
+  unregisterNetworkTransport: jest.fn(),
+  getNetworkTransport: jest.fn(),
+}));
+jest.mock('../utils/logger', () => ({
+  warn: jest.fn(),
+}));
 
 describe('singleton logger', () => {
+  beforeEach(() => {
+    (transportRegistry.getNetworkTransport as jest.Mock).mockReturnValue(
+      undefined
+    );
+  });
+
   afterEach(() => {
     logger.disableXHRInterception();
     jest.resetAllMocks();
+    (transportRegistry.getNetworkTransport as jest.Mock).mockReturnValue(
+      undefined
+    );
   });
+
   it('should set options when starting the logger', () => {
     (XHRInterceptor.isInterceptorEnabled as jest.Mock).mockReturnValueOnce(
       false
@@ -49,6 +68,28 @@ describe('singleton logger', () => {
     expect(XHRInterceptor.setResponseCallback).toHaveBeenCalledTimes(1);
     expect(XHRInterceptor.enableInterception).toHaveBeenCalledTimes(1);
     expect(logger.enabled).toBe(true);
+  });
+
+  it('should start a registered transport when requested', () => {
+    const transport = {
+      isInterceptorEnabled: jest.fn().mockReturnValue(false),
+      setOpenCallback: jest.fn(),
+      setRequestHeaderCallback: jest.fn(),
+      setSendCallback: jest.fn(),
+      setHeaderReceivedCallback: jest.fn(),
+      setResponseCallback: jest.fn(),
+      enableInterception: jest.fn(),
+      disableInterception: jest.fn(),
+    };
+
+    (transportRegistry.getNetworkTransport as jest.Mock).mockReturnValueOnce(
+      transport
+    );
+
+    startNetworkLogging({ transport: 'native' });
+
+    expect(transport.enableInterception).toHaveBeenCalledTimes(1);
+    expect(XHRInterceptor.enableInterception).toHaveBeenCalledTimes(0);
   });
 
   it('should not start twice the logger', () => {

--- a/src/components/NetworkLogger.tsx
+++ b/src/components/NetworkLogger.tsx
@@ -16,6 +16,7 @@ interface Props {
   sort?: 'asc' | 'desc';
   compact?: boolean;
   maxRows?: number;
+  autoStart?: boolean;
 }
 
 const sortRequests = (requests: NetworkRequestInfo[], sort: 'asc' | 'desc') => {
@@ -30,6 +31,7 @@ const NetworkLogger: React.FC<Props> = ({
   sort = 'desc',
   compact = false,
   maxRows,
+  autoStart = false,
 }) => {
   const [requests, setRequests] = useState(logger.getRequests());
   const [request, setRequest] = useState<NetworkRequestInfo>();
@@ -52,14 +54,16 @@ const NetworkLogger: React.FC<Props> = ({
       setRequests([...updatedRequests]);
     });
 
-    logger.enableXHRInterception();
+    if (autoStart) {
+      logger.enableXHRInterception();
+    }
     setMounted(true);
 
     return () => {
       // no-op if component is unmounted
       logger.setCallback(() => {});
     };
-  }, [sort]);
+  }, [sort, autoStart]);
 
   useEffect(() => {
     const onBack = () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,9 @@
 import logger from './loggerSingleton';
 import { StartNetworkLoggingOptions } from './types';
+import {
+  registerNetworkTransport,
+  unregisterNetworkTransport,
+} from './transportRegistry';
 
 export { default } from './components/NetworkLogger';
 
@@ -16,5 +20,7 @@ export const getRequests = () => logger.getRequests();
 export const clearRequests = () => logger.clearRequests();
 
 export { getBackHandler } from './backHandler';
+export { registerNetworkTransport, unregisterNetworkTransport };
+export type { NetworkTransportAdapter } from './transportRegistry';
 
 export type { ThemeName, Theme } from './theme';

--- a/src/index.web.tsx
+++ b/src/index.web.tsx
@@ -1,4 +1,8 @@
 import { StartNetworkLoggingOptions } from './types';
+import {
+  registerNetworkTransport,
+  unregisterNetworkTransport,
+} from './transportRegistry';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const startNetworkLogging = (options?: StartNetworkLoggingOptions) => {
@@ -8,6 +12,8 @@ export const startNetworkLogging = (options?: StartNetworkLoggingOptions) => {
 export const getRequests = () => [];
 
 export const clearRequests = () => {};
+export { registerNetworkTransport, unregisterNetworkTransport };
+export type { NetworkTransportAdapter } from './transportRegistry';
 
 export { getBackHandler } from './backHandler';
 

--- a/src/transportRegistry.ts
+++ b/src/transportRegistry.ts
@@ -1,0 +1,25 @@
+export type NetworkTransportAdapter = {
+  isInterceptorEnabled: () => boolean;
+  setOpenCallback: (callback: (...args: any[]) => void) => void;
+  setRequestHeaderCallback: (callback: (...args: any[]) => void) => void;
+  setSendCallback: (callback: (...args: any[]) => void) => void;
+  setHeaderReceivedCallback: (callback: (...args: any[]) => void) => void;
+  setResponseCallback: (callback: (...args: any[]) => void) => void;
+  enableInterception: () => void;
+  disableInterception: () => void;
+};
+
+const transports = new Map<string, NetworkTransportAdapter>();
+
+export const registerNetworkTransport = (
+  name: string,
+  transport: NetworkTransportAdapter
+) => {
+  transports.set(name, transport);
+};
+
+export const unregisterNetworkTransport = (name: string) => {
+  transports.delete(name);
+};
+
+export const getNetworkTransport = (name: string) => transports.get(name);

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,12 @@ export type RequestMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
 export type StartNetworkLoggingOptions = {
   /**
+   * Select logging transport.
+   * - `js`: JavaScript XHR interception (default)
+   * - any registered transport name via registerNetworkTransport(...)
+   */
+  transport?: 'js' | string;
+  /**
    * Max number of requests to keep before overwriting
    * @default 500
    */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "rootDir": ".",
     "paths": {
-      "react-native-network-logger": ["./src/index"]
+      "react-native-network-logger": ["./src/index"],
+      "react-native-network-logger-native": [
+        "./react-native-network-logger-native/src/index"
+      ]
     },
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10837,6 +10837,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"react-native-network-logger-native@workspace:react-native-network-logger-native":
+  version: 0.0.0-use.local
+  resolution: "react-native-network-logger-native@workspace:react-native-network-logger-native"
+  dependencies:
+    react-native-builder-bob: ^0.40.18
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+    react-native-network-logger: "*"
+  languageName: unknown
+  linkType: soft
+
 "react-native-network-logger@workspace:.":
   version: 0.0.0-use.local
   resolution: "react-native-network-logger@workspace:."


### PR DESCRIPTION
- new module allows you to turn on native support to capture all network requests the app makes rather than just ones made within react native

Closes #122
